### PR TITLE
Add requirements for testing ruby/ruby

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,9 @@ RUN set -ex && \
             zlib1g-dev \
             $(cat /tmp/ruby_build_deps.txt)
 
+RUN set -ex && \
+    useradd -ms /bin/bash ubuntu
+
 ADD tmp/ruby /usr/src/ruby
 ADD install_ruby.sh /tmp/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,9 @@ RUN set -ex && \
             libssl-dev \
             libyaml-dev \
             make \
+            autoconf \
+            bison \
+            git \
             tzdata \
             zlib1g-dev \
             $(cat /tmp/ruby_build_deps.txt)

--- a/ruby_build_deps.txt
+++ b/ruby_build_deps.txt
@@ -1,7 +1,4 @@
-autoconf
-bison
 dpkg-dev
-git-core
 ruby
 wget
 xz-utils


### PR DESCRIPTION
I hope to re-use this docker image for testing `test-bundled-gems` and `test-bundler` with ruby core repository.

Their requirements are:

* Non-root user. Some tests are failed with the root account.
* build-deps for building ruby source from the canonical repository.

@mrkn How about this?