### PR TITLE
The repository seems to be transferred to ruby

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# RubyData/ruby-docker-images
+# ruby/ruby-docker-images
 
 Built images are available here:
 https://hub.docker.com/r/rubylang/ruby/


### PR DESCRIPTION
Neither GitHub repository name nor DockerHub repository name includes "RubyData" now.