### PR TITLE
Remove BUNDLER_VERSION env variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,6 @@ ADD install_ruby.sh /tmp/
 ARG RUBY_VERSION=2.6.3
 ENV RUBY_VERSION=$RUBY_VERSION
 ENV RUBYGEMS_VERSION=3.0.3
-ENV BUNDLER_VERSION=1.17.3
 
 RUN set -ex && \
 # skip installing gem documentation

--- a/install_ruby.sh
+++ b/install_ruby.sh
@@ -5,7 +5,6 @@ set -ex
 RUBY_VERSION=${RUBY_VERSION-2.6.0}
 RUBY_MAJOR=$(echo $RUBY_VERSION | sed -E 's/\.[0-9]+(-.*)?$//g')
 RUBYGEMS_VERSION=${RUBYGEMS_VERSION-3.0.3}
-BUNDLER_VERSION=${BUNDLER_VERSION-1.17.3}
 
 wget -O index.txt "https://cache.ruby-lang.org/pub/ruby/index.txt"
 
@@ -79,20 +78,9 @@ fi
   rm -rf /tmp/ruby-build
 )
 
-case $RUBY_VERSION in
-  trunk)
-    # DO NOTHING
-    ;;
-  2.7.*)
-    # DO NOTHING
-    ;;
-  2.6.*)
-    # DO NOTHING
-    ;;
-  *)
-    gem update --system "$RUBYGEMS_VERSION"
-    gem install bundler --version "$BUNDLER_VERSION" --force
-    ;;
-esac
+gem update --system "$RUBYGEMS_VERSION"
 
 rm -fr /usr/src/ruby /root/.gem/
+
+# rough smoke test
+ruby --version && gem --version && bundle --version


### PR DESCRIPTION
Currently, `bundler --version` on ruby:2.7.0-preview-1-bionic doesn't work:

```
$ docker run rubylang/ruby:2.7.0-preview1-bionic bundler --version
/usr/local/lib/ruby/2.7.0/rubygems.rb:281:in `find_spec_for_exe': Could not find 'bundler' (1.17.3) required by `$BUNDLER_VERSION`. (Gem::GemNotFoundException)
To update to the latest version installed on your system, run `bundle update --bundler`.
To install the missing version, run `gem install bundler:1.17.3`
        from /usr/local/lib/ruby/2.7.0/rubygems.rb:300:in `activate_bin_path'
        from /usr/local/bin/bundler:23:in `<main>'
```

Because `BUNDLER_VERSION` restricts bundler version for bundler 2:
https://github.com/docker-library/ruby/issues/246

On docker-library, it was already solved by removing BUNDLER_VERSION and installing newer rubygems:
https://github.com/docker-library/ruby/pull/255