### PR TITLE
Revert "Remove BUNDLER_VERSION env variable"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,7 @@ ADD install_ruby.sh /tmp/
 ARG RUBY_VERSION=2.6.3
 ENV RUBY_VERSION=$RUBY_VERSION
 ENV RUBYGEMS_VERSION=3.0.3
+ENV BUNDLER_VERSION=1.17.3
 
 RUN set -ex && \
 # skip installing gem documentation

--- a/install_ruby.sh
+++ b/install_ruby.sh
@@ -5,6 +5,7 @@ set -ex
 RUBY_VERSION=${RUBY_VERSION-2.6.0}
 RUBY_MAJOR=$(echo $RUBY_VERSION | sed -E 's/\.[0-9]+(-.*)?$//g')
 RUBYGEMS_VERSION=${RUBYGEMS_VERSION-3.0.3}
+BUNDLER_VERSION=${BUNDLER_VERSION-1.17.3}
 
 wget -O index.txt "https://cache.ruby-lang.org/pub/ruby/index.txt"
 
@@ -78,9 +79,20 @@ fi
   rm -rf /tmp/ruby-build
 )
 
-gem update --system "$RUBYGEMS_VERSION"
+case $RUBY_VERSION in
+  trunk)
+    # DO NOTHING
+    ;;
+  2.7.*)
+    # DO NOTHING
+    ;;
+  2.6.*)
+    # DO NOTHING
+    ;;
+  *)
+    gem update --system "$RUBYGEMS_VERSION"
+    gem install bundler --version "$BUNDLER_VERSION" --force
+    ;;
+esac
 
 rm -fr /usr/src/ruby /root/.gem/
-
-# rough smoke test
-ruby --version && gem --version && bundle --version


### PR DESCRIPTION
Reverts ruby/ruby-docker-images#5 because the circleci workflow was failed.
https://circleci.com/gh/ruby/ruby-docker-images/316?utm_campaign=workflow-failed&utm_medium=email&utm_source=notification