### PR TITLE
Remove BUNDLER_VERSION environment variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,6 @@ ADD install_ruby.sh /tmp/
 ARG RUBY_VERSION=2.6.3
 ENV RUBY_VERSION=$RUBY_VERSION
 ENV RUBYGEMS_VERSION=3.0.3
-ENV BUNDLER_VERSION=1.17.3
 
 RUN set -ex && \
 # skip installing gem documentation

--- a/install_ruby.sh
+++ b/install_ruby.sh
@@ -5,7 +5,6 @@ set -ex
 RUBY_VERSION=${RUBY_VERSION-2.6.0}
 RUBY_MAJOR=$(echo $RUBY_VERSION | sed -E 's/\.[0-9]+(-.*)?$//g')
 RUBYGEMS_VERSION=${RUBYGEMS_VERSION-3.0.3}
-BUNDLER_VERSION=${BUNDLER_VERSION-1.17.3}
 
 wget -O index.txt "https://cache.ruby-lang.org/pub/ruby/index.txt"
 
@@ -91,8 +90,10 @@ case $RUBY_VERSION in
     ;;
   *)
     gem update --system "$RUBYGEMS_VERSION"
-    gem install bundler --version "$BUNDLER_VERSION" --force
     ;;
 esac
 
 rm -fr /usr/src/ruby /root/.gem/
+
+# rough smoke test
+(cd && ruby --version && gem --version && bundle --version)


### PR DESCRIPTION
This pull request removes  BUNDLER_VERSION environment variable

* No need to install bundler separately because `gem update --system 3.0.3` installs bundler 1.17.3

Refer one of the minor enhancements of RubyGems 3.0.2:

https://github.com/rubygems/rubygems/blob/919239f65daf74bce53935e191e0e57aabcb80a7/History.txt#L74

RubyGems 3.0.3 only has security fixes. No Bundler version bump found.

* Exporting `BUNDLER_VERSION=1.17.3` causes the error at Ruby 2.7.0 master
which installs `Bundler version 2.1.0.pre.1`

```
/usr/local/lib/ruby/2.7.0/rubygems.rb:281:in `find_spec_for_exe': Could not find 'bundler' (1.17.3) required by `$BUNDLER_VERSION`. (Gem::GemNotFoundException)
```

* Add a rough smoke test to show which RubyGem and Bundler versions installed

Refer #5
Co-authored-by: Fumiaki MATSUSHIMA <mtsmfm@gmail.com>