### PR TITLE
Enable push for nightly build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -191,3 +191,4 @@ workflows:
     jobs:
       - build_trunk:
           nightly: true
+          push: true


### PR DESCRIPTION
I changed circleci config in #7 and I forgot to add this flag to build_trunk 🙇 

As a result, trunk isn't pushed since my PR got merged 🙇 🙇 🙇 

![image](https://user-images.githubusercontent.com/1796864/63769936-f9d93e80-c90e-11e9-93d4-cac08510a5bf.png)

https://hub.docker.com/r/rubylang/ruby/tags