### PR TITLE
Fix s/trunk/master/

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,12 +16,12 @@ commands:
             curl -L -o /tmp/docker-$VER.tgz https://download.docker.com/linux/static/stable/x86_64/docker-$VER.tgz
             tar -xz -C /tmp -f /tmp/docker-$VER.tgz
             mv /tmp/docker/* /usr/bin
-  checkout_ruby_trunk:
-    description: "Checkout Ruby trunk"
+  checkout_ruby_master:
+    description: "Checkout Ruby master"
     steps:
       - restore_cache:
           keys:
-            - ruby-trunk
+            - ruby-master
       - run:
           command: |
             if test -f tmp/ruby/configure.ac; then
@@ -32,7 +32,7 @@ commands:
               git clone https://github.com/ruby/ruby.git tmp/ruby
             fi
       - save_cache:
-          key: ruby-trunk
+          key: ruby-master
           paths:
             - tmp/ruby
   build_image:
@@ -40,7 +40,7 @@ commands:
     parameters:
       ruby_version:
         type: string
-        default: "trunk"
+        default: "master"
       nightly:
         type: boolean
         default: false
@@ -59,7 +59,7 @@ commands:
             docker push rubylang/ruby
 
 jobs:
-  build_trunk:
+  build_master:
     parameters:
       nightly:
         type: boolean
@@ -74,9 +74,9 @@ jobs:
       - checkout
       - setup_remote_docker
       - install_docker_client
-      - checkout_ruby_trunk
+      - checkout_ruby_master
       - build_image:
-          ruby_version: "trunk"
+          ruby_version: "master"
           nightly: << parameters.nightly >>
       - when:
           condition: <<parameters.push>>
@@ -164,13 +164,13 @@ workflows:
 
   github:
     jobs:
-      - build_trunk:
+      - build_master:
           push: true
           filters:
             branches:
               only:
                 - master
-      - build_trunk:
+      - build_master:
           filters:
             branches:
               ignore:
@@ -189,6 +189,6 @@ workflows:
               only:
                 - master
     jobs:
-      - build_trunk:
+      - build_master:
           nightly: true
           push: true

--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ https://hub.docker.com/r/rubylang/ruby/
 rake docker:build ruby_version=<Ruby version you want to build>
 ```
 
-You can specify the specific revision in the trunk branch like:
+You can specify the specific revision in the master branch like:
 
 ```
-rake docker:build ruby_version=trunk:ce798d08de
+rake docker:build ruby_version=master:ce798d08de
 ```
 
 ## Author

--- a/Rakefile
+++ b/Rakefile
@@ -11,16 +11,16 @@ namespace :docker do
     "bionic"
   end
 
-  def get_ruby_trunk_head_hash
-    `curl -H 'accept: application/vnd.github.v3.sha' https://api.github.com/repos/ruby/ruby/commits/trunk`.chomp
+  def get_ruby_master_head_hash
+    `curl -H 'accept: application/vnd.github.v3.sha' https://api.github.com/repos/ruby/ruby/commits/master`.chomp
   end
 
   def make_tag_args(ruby_version)
     ruby_ver2 = ruby_version.split('.')[0,2].join('.')
-    if /\Atrunk(?::([\da-f]+))?\z/ =~ ruby_version
-      commit_hash = Regexp.last_match[1] || get_ruby_trunk_head_hash
-      ruby_version = "trunk:#{commit_hash}"
-      tags = ["trunk", "trunk-#{commit_hash}"]
+    if /\Amaster(?::([\da-f]+))?\z/ =~ ruby_version
+      commit_hash = Regexp.last_match[1] || get_ruby_master_head_hash
+      ruby_version = "master:#{commit_hash}"
+      tags = ["master", "master-#{commit_hash}"]
     else
       tags = ["#{ruby_ver2}", "#{ruby_version}"]
     end
@@ -36,12 +36,12 @@ namespace :docker do
       IO.write('tmp/ruby/.keep', '')
     end
     sh 'docker', 'build', *tag_args, '--build-arg', "RUBY_VERSION=#{ruby_version}", '.'
-    if ruby_version.start_with? 'trunk'
+    if ruby_version.start_with? 'master'
       image_name = tag_args[3]
       if ENV['nightly']
         today = Time.now.getlocal("+09:00").strftime('%Y%m%d')
-        sh 'docker', 'tag', image_name, image_name.sub(/trunk-([\da-f]+)/, "trunk-nightly-#{today}")
-        sh 'docker', 'tag', image_name, image_name.sub(/trunk-([\da-f]+)/, "trunk-nightly")
+        sh 'docker', 'tag', image_name, image_name.sub(/master-([\da-f]+)/, "master-nightly-#{today}")
+        sh 'docker', 'tag', image_name, image_name.sub(/master-([\da-f]+)/, "master-nightly")
       end
     end
   end

--- a/install_ruby.sh
+++ b/install_ruby.sh
@@ -9,9 +9,9 @@ RUBYGEMS_VERSION=${RUBYGEMS_VERSION-3.0.3}
 wget -O index.txt "https://cache.ruby-lang.org/pub/ruby/index.txt"
 
 case $RUBY_VERSION in
-  trunk:*)
-    RUBY_TRUNK_COMMIT=$(echo $RUBY_VERSION | awk -F: '{print $2}' )
-    RUBY_VERSION=trunk
+  master:*)
+    RUBY_MASTER_COMMIT=$(echo $RUBY_VERSION | awk -F: '{print $2}' )
+    RUBY_VERSION=master
     ;;
   2.7.0-preview1)
     RUBY_DOWNLOAD_SHA256=8c546df3345398b3edc9d0ab097846f033783d33762889fd0f3dc8bb465c3354
@@ -34,7 +34,7 @@ case $RUBY_VERSION in
     ;;
 esac
 
-if test -n "$RUBY_TRUNK_COMMIT"; then
+if test -n "$RUBY_MASTER_COMMIT"; then
   if test -f /usr/src/ruby/configure.ac; then
     cd /usr/src/ruby
     git pull --rebase origin
@@ -43,7 +43,7 @@ if test -n "$RUBY_TRUNK_COMMIT"; then
     git clone https://github.com/ruby/ruby.git /usr/src/ruby
     cd /usr/src/ruby
   fi
-  git checkout $RUBY_TRUNK_COMMIT
+  git checkout $RUBY_MASTER_COMMIT
 else
   if test -z "$RUBY_DOWNLOAD_URI"; then
     RUBY_DOWNLOAD_URI="https://cache.ruby-lang.org/pub/ruby/${RUBY_MAJOR}/ruby-${RUBY_VERSION}.tar.xz"
@@ -79,7 +79,7 @@ fi
 )
 
 case $RUBY_VERSION in
-  trunk)
+  master)
     # DO NOTHING
     ;;
   2.7.*)


### PR DESCRIPTION
After 4 months from now, trunk branch will be removed. Thus we should not rely on the branch at least. I also prefer renaming tag names for consistency.