### PR TITLE
Added the git repo provided by PPA. 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,8 @@ ENV DEBIAN_FRONTEND noninteractive
 
 ADD ruby_build_deps.txt /tmp/
 
+RUN apt-add-repository ppa:git-core/ppa
+
 RUN set -ex && \
     \
     apt-get update && \


### PR DESCRIPTION
When we use the `actions/checkout@v2` in GitHub Actions, It needs to `>= git 2.18` for full of features. 

Ubuntu bionic provide git-2.17.1. It's nice to upgrade the git version for users.

How about this?