### PR TITLE
Delete apt cache every execute apt command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,11 @@ RUN set -ex && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
       software-properties-common && \
-    apt-add-repository ppa:git-core/ppa
+    apt-add-repository ppa:git-core/ppa && \
+    apt-get clean && rm -r /var/lib/apt/lists/*
 
 RUN set -ex && \
+    apt-get update && \
     apt-get install -y --no-install-recommends \
             ca-certificates \
             gcc \
@@ -30,7 +32,8 @@ RUN set -ex && \
             git \
             tzdata \
             zlib1g-dev \
-            $(cat /tmp/ruby_build_deps.txt)
+            $(cat /tmp/ruby_build_deps.txt) && \
+            apt-get clean && rm -r /var/lib/apt/lists/*
 
 RUN set -ex && \
     useradd -ms /bin/bash ubuntu
@@ -62,7 +65,5 @@ RUN set -ex && \
       | xargs apt-mark manual && \
     \
     apt-get purge -y --auto-remove $(cat /tmp/ruby_build_deps.txt) && \
-    rm /tmp/ruby_build_deps.txt && \
-    \
-    apt-get clean && \
-    rm -r /var/lib/apt/lists/*
+    rm /tmp/ruby_build_deps.txt
+

--- a/Dockerfile-arm64
+++ b/Dockerfile-arm64
@@ -24,7 +24,8 @@ RUN set -ex && \
             git \
             tzdata \
             zlib1g-dev \
-            $(cat /tmp/ruby_build_deps.txt)
+            $(cat /tmp/ruby_build_deps.txt) && \
+            apt-get clean && rm -r /var/lib/apt/lists/*
 
 RUN set -ex && \
     useradd -ms /bin/bash ubuntu
@@ -56,7 +57,4 @@ RUN set -ex && \
       | xargs apt-mark manual && \
     \
     apt-get purge -y --auto-remove $(cat /tmp/ruby_build_deps.txt) && \
-    rm /tmp/ruby_build_deps.txt && \
-    \
-    apt-get clean && \
-    rm -r /var/lib/apt/lists/*
+    rm /tmp/ruby_build_deps.txt


### PR DESCRIPTION
Hi team!
thanks for your contribution to Ruby!

This PR is to adjust to Docker build Best Practice. 
https://docs.docker.com/develop/develop-images/dockerfile_best-practices/

Acording to *Best practices for writing Dockerfiles*, apt list is cached to Docker image when `rm -r /var/lib/apt/lists/*`  execute that defferent `apt install or apt update` RUN command.

> In addition, when you clean up the apt cache by removing /var/lib/apt/lists it reduces the image size, since the apt cache is not stored in a layer. Since the RUN statement starts with apt-get update, the package cache is always refreshed prior to apt-get install.

I think it's a bit verbose, but I tried to delete the cache after the every apt command.
Thanks.
