### PR TITLE
delete /tmp/www after clone

### DIFF
--- a/install_ruby.sh
+++ b/install_ruby.sh
@@ -7,7 +7,6 @@ RUBY_MAJOR=$(echo $RUBY_VERSION | sed -E 's/\.[0-9]+(-.*)?$//g')
 RUBYGEMS_VERSION=${RUBYGEMS_VERSION-3.0.3}
 
 function get_released_ruby() {
-  rm -rf /tmp/www
   git clone --depth 1 https://github.com/ruby/www.ruby-lang.org.git /tmp/www
 
   cat << RUBY | ruby - $1 /tmp/www/_data/releases.yml
@@ -17,6 +16,7 @@ releases = Psych.load_file(ARGV[1])
 release = releases.find {|x| x["version"] == version }
 puts "#{release["url"]["xz"]} #{release["sha256"]["xz"]}"
 RUBY
+  rm -rf /tmp/www
 }
 
 case $RUBY_VERSION in


### PR DESCRIPTION
Hi Team!
Since the tmp file remains after downloading Ruby, the old version of Gemfile.lock remains, and some Docker image scanners have determined that it is vulnerable, so delete unnecessary files. ..

Rubyのダウンロード後にtmpファイルが残っていることで、tmp/www/Gemfile.lockの古いバージョンが残っており、一部のDockerイメージのスキャナーで脆弱性があると判定されているので、不要なファイルは削除します。