### PR TITLE
Add --all-tags option to push all images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Push images to DockerHub
-        run: docker push rubylang/ruby
+        run: docker push rubylang/ruby --all-tags
 
       - name: Renaming images
         run: |
@@ -51,4 +51,4 @@ jobs:
           echo $GHCR_TOKEN | docker login ghcr.io -u owner --password-stdin
 
       - name: Push image to GitHub Container Registry
-        run: docker push ghcr.io/${{ github.repository_owner }}/ruby
+        run: docker push ghcr.io/${{ github.repository_owner }}/ruby --all-tags


### PR DESCRIPTION
Fix: https://github.com/ruby/ruby-docker-images/runs/2136097570?check_suite_focus=true

Hi Team!

[3 months ago, `ubuntu-latest` was `ubuntu-18.04`](https://github.com/ruby/ruby-docker-images/runs/1607733686?check_suite_focus=true#step:1:4), so the docker command was older and could push all images without options.

[Now it's `ubuntu-20.04`](https://github.com/ruby/ruby-docker-images/runs/2136097570?check_suite_focus=true#step:1:4), so you need the `--all-tags` option to push all tags.