### PR TITLE
Support Psych 4.0 which is bundled with Ruby 3.1

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -22,7 +22,7 @@ def ruby_versions
   unless @ruby_versions
     require "psych"
     releases_yml = download("https://raw.githubusercontent.com/ruby/www.ruby-lang.org/master/_data/releases.yml")
-    releases = Psych.load(releases_yml, "releases.yml")
+    releases = Psych.respond_to?(:unsafe_load) ? Psych.unsafe_load(releases_yml, filename: "releases.yml") : Psych.load(releases_yml, "releases.yml")
     versions = {}
     releases.each do |release|
       version = release["version"]


### PR DESCRIPTION
This pull request allows Ruby 3.1 which bundles Psych 4 to build Docker images.

* Without this commit

```ruby
$ ruby -v
ruby 3.1.0p0 (2021-12-25 revision fb4df44d16) [x86_64-linux]
$ gem info psych

*** LOCAL GEMS ***

psych (4.0.3)
    Authors: Aaron Patterson, SHIBATA Hiroshi, Charles Oliver Nutter
    Homepage: https://github.com/ruby/psych
    License: MIT
    Installed at (default): /home/yahonda/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0

    Psych is a YAML parser and emitter
$ rake -v docker:build ruby_version=3.1.0
rake aborted!
ArgumentError: wrong number of arguments (given 2, expected 1)
/home/yahonda/src/github.com/ruby/ruby-docker-images/Rakefile:25:in `ruby_versions'
/home/yahonda/src/github.com/ruby/ruby-docker-images/Rakefile:46:in `ruby_version_exist?'
/home/yahonda/src/github.com/ruby/ruby-docker-images/Rakefile:111:in `block (2 levels) in <top (required)>'
Tasks: TOP => docker:build
(See full trace by running task with --trace)
$
```

* With this commit

```ruby
$ ruby -v
ruby 3.1.0p0 (2021-12-25 revision fb4df44d16) [x86_64-linux]
$ gem info psych

*** LOCAL GEMS ***

psych (4.0.3)
    Authors: Aaron Patterson, SHIBATA Hiroshi, Charles Oliver Nutter
    Homepage: https://github.com/ruby/psych
    License: MIT
    Installed at (default): /home/yahonda/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0

    Psych is a YAML parser and emitter
$ rake -v docker:build ruby_version=3.1.0
docker build -f Dockerfile -t rubylang/ruby:3.1 -t rubylang/ruby:3.1-focal -t rubylang/ruby:3.1.0-focal --build-arg cppflags= --build-arg optflags= --build-arg RUBY_VERSION=3.1.0 --build-arg BASE_IMAGE_TAG=focal .
Sending build context to Docker daemon  350.2kB
Step 1/17 : ARG BASE_IMAGE_TAG=focal
... snip ...
Successfully built d2ecb8c8fd13
Successfully tagged rubylang/ruby:3.1
Successfully tagged rubylang/ruby:3.1-focal
Successfully tagged rubylang/ruby:3.1.0-focal
$
```

* With this commit and use Ruby 3.0.3 which bundles psych 3.3.2

```ruby
$ ruby -v
ruby 3.0.3p157 (2021-11-24 revision 3fb7d2cadc) [x86_64-linux]
$ gem info psych

*** LOCAL GEMS ***

psych (3.3.2)
    Authors: Aaron Patterson, SHIBATA Hiroshi, Charles Oliver Nutter
    Homepage: https://github.com/ruby/psych
    License: MIT
    Installed at (default): /home/yahonda/.rbenv/versions/3.0.3/lib/ruby/gems/3.0.0

    Psych is a YAML parser and emitter
$ rake -v docker:build ruby_version=3.1.0
docker build -f Dockerfile -t rubylang/ruby:3.1 -t rubylang/ruby:3.1-focal -t rubylang/ruby:3.1.0-focal --build-arg cppflags= --build-arg optflags= --build-arg RUBY_VERSION=3.1.0 --build-arg BASE_IMAGE_TAG=focal .
Sending build context to Docker daemon  350.2kB
Step 1/17 : ARG BASE_IMAGE_TAG=focal
... snip ...
Successfully built b1588ff852ad
Successfully tagged rubylang/ruby:3.1
Successfully tagged rubylang/ruby:3.1-focal
Successfully tagged rubylang/ruby:3.1.0-focal
$
```
