### PR TITLE
Do not update RubyGems version for Ruby 3.1

### DIFF
--- a/install_ruby.sh
+++ b/install_ruby.sh
@@ -92,6 +92,9 @@ case $RUBY_VERSION in
   master)
     # DO NOTHING
     ;;
+  3.1.*)
+    # DO NOTHING
+    ;;
   3.0.*)
     # DO NOTHING
     ;;


### PR DESCRIPTION
This pull request changes not to update RubyGems version for Ruby 3.1.



* Without this commit, updating RubyGems version to 3.2.3

```ruby
$ rake docker:build ruby_version=3.1.0
... snip ...
+ rm -fr /usr/src/ruby /root/.gem/
+ cd
+ ruby --version
ruby 3.1.0p0 (2021-12-25 revision fb4df44d16) [x86_64-linux]
+ gem --version
3.2.3
+ bundle --version
Calling `DidYouMean::SPELL_CHECKERS.merge!(error_name => spell_checker)' has been deprecated. Please call `DidYouMean.correct_error(error_name, spell_checker)' instead.
Bundler version 2.2.3
```

* With this commit, using RubyGems version is 3.3.3

```ruby
$ rake docker:build ruby_version=3.1.0
... snip ...
+ rm -fr /usr/src/ruby /root/.gem/
+ cd
+ ruby --version
ruby 3.1.0p0 (2021-12-25 revision fb4df44d16) [x86_64-linux]
+ gem --version
3.3.3
+ bundle --version
Bundler version 2.3.3
```