### PR TITLE
Changes in order to build an image with a ruby version below 2.6 on an arm64 arch

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -130,7 +130,7 @@ namespace :docker do
       IO.write('tmp/ruby/.keep', '')
     end
     env_args = %w(cppflags optflags).map {|name| ["--build-arg", "#{name}=#{ENV[name]}"] }.flatten
-    sh 'docker', 'run', '--rm', '--privileged', 'multiarch/qemu-user-static:register', '--reset' if arch
+    sh 'docker', 'run', '--rm', '--privileged', 'multiarch/qemu-user-static:register', '--reset' if arch && arch != 'arm64'
     sh 'docker', 'build', '-f', dockerfile, *tag_args, *env_args,
        '--build-arg', "RUBY_VERSION=#{ruby_version}",
        '--build-arg', "BASE_IMAGE_TAG=#{ubuntu_version(ruby_version)}",

--- a/install_ruby.sh
+++ b/install_ruby.sh
@@ -42,6 +42,11 @@ case $RUBY_VERSION in
     ;;
 esac
 
+# Since Ruby 2.6, Bundler is a part of Ruby’s standard library, but below this version we need to install Bundler.
+ if [ "$(printf '%s\n' "$RUBY_VERSION" "2.6.0" | sort -V | head -n1)" = "$RUBY_VERSION" ]; then
+  gem install bundler
+fi
+
 if test -n "$RUBY_MASTER_COMMIT"; then
   if test -f /usr/src/ruby/configure.ac; then
     cd /usr/src/ruby


### PR DESCRIPTION
It was impossible to build an image with a version of Ruby below 2.6 for a arm64 arch.

So two modifications were added:
- no need to run docker through qemu on an arm64 arch.
- we need to install Bundler if the Ruby version is below 2.6 (Bundler becomes a part of Ruby’s standard library since 2.6).