### PR TITLE
Fix wrong base image for some arm64 images

### DIFF
--- a/Dockerfile-arm64
+++ b/Dockerfile-arm64
@@ -1,4 +1,5 @@
-FROM multiarch/ubuntu-core:arm64-bionic
+ARG BASE_IMAGE_TAG=focal
+FROM multiarch/ubuntu-core:arm64-$BASE_IMAGE_TAG
 
 ENV LANG C.UTF-8
 ENV DEBIAN_FRONTEND noninteractive


### PR DESCRIPTION
Some images for arm64 are built with wrong base image like bellow.

```
$ docker run --rm rubylang/ruby:3.1.2-focal-arm64 cat /etc/lsb-release
DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=18.04
DISTRIB_CODENAME=bionic
DISTRIB_DESCRIPTION="Ubuntu 18.04.6 LTS"
```

So, I fixed `Dockerfile-arm64` file enable to change the base image tag same as `Dockerfile`.