### PR TITLE
Resolve differences between Dockerfile and Dockerfile-arm64

### DIFF
--- a/Dockerfile-arm64
+++ b/Dockerfile-arm64
@@ -12,6 +12,7 @@ RUN set -ex && \
     apt-get install -y --no-install-recommends \
             ca-certificates \
             gcc \
+            g++ \
             libffi-dev \
             libgdbm-dev \
             libgmp-dev \

--- a/Dockerfile-arm64
+++ b/Dockerfile-arm64
@@ -7,7 +7,13 @@ ENV DEBIAN_FRONTEND noninteractive
 COPY ruby_build_deps.txt /tmp/
 
 RUN set -ex && \
-    \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+      software-properties-common && \
+    apt-add-repository ppa:git-core/ppa && \
+    apt-get clean && rm -r /var/lib/apt/lists/*
+
+RUN set -ex && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
             ca-certificates \


### PR DESCRIPTION
Resolve differences between `Dockerfile` and `Dockerfile-arm64`.

Newer git brings better experience for developers and some gems like sassc need g++ to build. And I think that the fewer differences between architectures is better.