### PR TITLE
Install rust and enable yjit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,8 +31,7 @@ RUN set -ex && \
             bison \
             git \
             tzdata \
-            zlib1g-dev \
-            $(cat /tmp/ruby_build_deps.txt) && \
+            zlib1g-dev && \
             apt-get clean && rm -r /var/lib/apt/lists/*
 
 RUN set -ex && \
@@ -49,7 +48,9 @@ ARG optflags
 ARG debugflags
 ARG cppflags
 
-RUN set -ex && \
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends $(cat /tmp/ruby_build_deps.txt) && \
+    set -ex && \
 # skip installing gem documentation
     mkdir -p /usr/local/etc && \
     { \
@@ -65,4 +66,5 @@ RUN set -ex && \
       | xargs apt-mark manual && \
     \
     apt-get purge -y --auto-remove $(cat /tmp/ruby_build_deps.txt) && \
+    apt-get clean && rm -r /var/lib/apt/lists/* && \
     rm /tmp/ruby_build_deps.txt

--- a/install_ruby.sh
+++ b/install_ruby.sh
@@ -76,6 +76,7 @@ fi
     --prefix=/usr/local \
     --disable-install-doc \
     --enable-shared \
+    --enable-yjit \
     ${cppflags:+cppflags="${cppflags}"} \
     ${optflags:+optflags="${debugflags}"} \
     optflags="${optflags:--O3}" \

--- a/ruby_build_deps.txt
+++ b/ruby_build_deps.txt
@@ -2,3 +2,4 @@ dpkg-dev
 ruby
 wget
 xz-utils
+rustc


### PR DESCRIPTION
This PR installs Rust in the Dockerfile and enables yjit in the images. The change here is useful for using and testing yjit without being required to manually configure Ruby. One usecase is to add a build to rails/rails to test our code against yjit.

I tested this locally and was able to build the docker image and verified it built correctly and I could use yjit by running the following command:

```
$ RUBY_YJIT_ENABLE=1 ruby -e 'p RubyVM::YJIT.enabled?'
=> true
```