### PR TITLE
Migrate focal to jammy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ commands:
         default: "amd64"
       ubuntu_version:
         type: string
-        default: "focal"
+        default: "jammy"
       tag:
         type: string
         default: ""
@@ -108,7 +108,7 @@ jobs:
         default: "amd64"
       ubuntu_version:
         type: string
-        default: "focal"
+        default: "jammy"
       ruby_version:
         type: string
         default: "master"
@@ -158,7 +158,7 @@ jobs:
         default: false
       ubuntu_version:
         type: string
-        default: "focal"
+        default: "jammy"
     docker:
       - image: ruby:latest
     working_directory: ~/repo
@@ -184,7 +184,7 @@ jobs:
     parameters:
       tag:
         type: string
-        default: "3.1.2-focal"
+        default: "3.1.2-jammy"
     docker:
       - image: cimg/base:2022.06
     steps:
@@ -209,7 +209,7 @@ parameters:
     default: ""
   ubuntu_version:
     type: string
-    default: "focal"
+    default: "jammy"
 
 workflows:
   version: 2
@@ -226,7 +226,7 @@ workflows:
       - build_master:
           nightly: true
           push: true
-          ubuntu_version: "focal"
+          ubuntu_version: "jammy"
           executor: docker
       - build_master:
           nightly: true
@@ -237,7 +237,7 @@ workflows:
           nightly: true
           push: true
 
-  # Build amd64/arm64 multiarch docker image as "focal-3.1.2-multi"
+  # Build amd64/arm64 multiarch docker image as "jammy-3.1.2-multi"
   # only triggered when pipeline is kicked over API
   build_multiarch:
     when:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ on:
       UBUNTU_VERSION:
         description: The version of Ubuntu as the base image
         required: true
-        default: focal
+        default: jammy
       ARCH:
         description: Which architecture amd64 or arm64 do you want to build? (The default is amd64)
         required: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,10 @@
-ARG BASE_IMAGE_TAG=focal
+ARG BASE_IMAGE_TAG=jammy
 FROM ubuntu:$BASE_IMAGE_TAG
 
 ENV LANG C.UTF-8
 ENV DEBIAN_FRONTEND noninteractive
 
 COPY ruby_build_deps.txt /tmp/
-
-RUN set -ex && \
-    apt-get update && \
-    apt-get install -y --no-install-recommends \
-      software-properties-common && \
-    apt-add-repository ppa:git-core/ppa && \
-    apt-get clean && rm -r /var/lib/apt/lists/*
 
 RUN set -ex && \
     apt-get update && \

--- a/Rakefile
+++ b/Rakefile
@@ -75,7 +75,7 @@ namespace :docker do
     if ruby_version < "3.0"
       "bionic"
     else
-      "focal"
+      "jammy"
     end
   end
 


### PR DESCRIPTION
Today's workflow failed due to PPA https://app.circleci.com/pipelines/github/ruby/ruby-docker-images/1146/workflows/aa147695-694f-409c-b161-a15124fcad81. git version on Jammy is 2.34.1, so we wouldn't need https://github.com/ruby/ruby-docker-images/pull/17 if we switch to Jammy.