### PR TITLE
Use the same timezone as revision.h

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -139,7 +139,7 @@ namespace :docker do
     if ruby_version.start_with? 'master'
       image_name = tag_args[3]
       if ENV['nightly']
-        today = Time.now.getlocal("+09:00").strftime('%Y%m%d')
+        today = Time.now.utc.strftime('%Y%m%d')
         sh 'docker', 'tag', image_name, image_name.sub(/master#{suffix}-([\da-f]+)/, "master#{suffix}-nightly-#{today}")
         sh 'docker', 'tag', image_name, image_name.sub(/master#{suffix}-([\da-f]+)/, "master#{suffix}-nightly")
       end


### PR DESCRIPTION
It seems strange that the date in the Docker tag name and the one in RUBY_DESCRIPTION are inconsistent:

```
$ docker run --rm rubylang/ruby:master-nightly-20221125-focal ruby -v
ruby 3.2.0dev (2022-11-24T15:30:28Z master d2fa67de81) [x86_64-linux]
```

This is caused by the fact that ruby/ruby's revision.h uses UTC https://github.com/ruby/ruby/blob/ac4d00df824215d4b85d36cef75c76543fead33e/tool/lib/vcs.rb#L266 and ruby-docker-images uses JST. Using the same timezone between them seems more useful.