### PR TITLE
Remove `bison` since lrama merged to Ruby master branch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,6 @@ RUN set -ex && \
     \
     apt-get install -y --no-install-recommends \
             autoconf \
-            bison \
             ca-certificates \
             dpkg-dev \
             gcc \


### PR DESCRIPTION
This pull request removes `bison` since lrama merged to Ruby master branch.

Confirmed this commit works to build released versions of Ruby and master branch after the lrama merged as follows.

- It builds Ruby 3.2.2 successfully, assuming the released versions of Ruby do not require bison

```
$ rake docker:build ruby_version=3.2.2
... snip ...
Successfully built 1a4b5cab48d1
Successfully tagged rubylang/ruby:3.2.2-jammy
Successfully tagged rubylang/ruby:3.2-jammy
```

- It builds the latest master branch that includes [a1b01e7](https://github.com/ruby/ruby/commit/a1b01e7) successfully

```
$ rake docker:build ruby_version=master:0052132
... snip ...
Successfully built a6d7b2a472ed
Successfully tagged rubylang/ruby:master-jammy
Successfully tagged rubylang/ruby:master-0052132-jammy
```

- It failed to build the master branch [just before Lrama LALR parser generator merged ](https://github.com/ruby/ruby/commit/d314fe42f987fcfaad67f102ec418ee4ca32ee99) as expected

```
$ rake docker:build ruby_version=master:d314fe4c
... snip ...
compiling /usr/src/ruby/rational.c
make: bison: No such file or directory
make: *** [uncommon.mk:927: parse.c] Error 127
make: *** Waiting for unfinished jobs....
The command '/bin/sh -c set -ex &&     mkdir -p /usr/local/etc &&     {       echo 'install: --no-document';       echo 'update: --no-document';     } >> /usr/local/etc/gemrc &&         /tmp/install_ruby.sh' returned a non-zero code: 2
rake aborted!
Command failed with status (2): [docker build -f Dockerfile -t rubylang/rub...]
/home/yahonda/src/github.com/ruby/ruby-docker-images/Rakefile:210:in `block (2 levels) in <top (required)>'
Tasks: TOP => docker:build
(See full trace by running task with --trace)
$
```


Related to https://bugs.ruby-lang.org/issues/19637 https://github.com/ruby/ruby/pull/7798