### PR TITLE
rubylang/ruby:3.2-focal is rubylang/ruby:3.2.3-focal

### DIFF
--- a/README_dockerhub.md
+++ b/README_dockerhub.md
@@ -36,7 +36,7 @@ The list of image names in this repository is below:
 - 3.2
   - rubylang/ruby:3.2-focal
   - rubylang/ruby:3.2-dev-focal
-  - rubylang/ruby:3.2.2-focal
+  - rubylang/ruby:3.2.3-focal
   - rubylang/ruby:3.2.2-dev-focal
 - 3.1
   - rubylang/ruby:3.1-focal


### PR DESCRIPTION
But there is not `rubylang/ruby:3.2.3-dev-focal`, and `docker run --rm -it rubylang/ruby:3.2-dev-focal ruby -v` outputs `ruby 3.2.2 (2023-03-30 revision e51014f9c0) [aarch64-linux]`.