### PR TITLE
Convert ruby/ruby-docker-images to GitHub Actions

### DIFF
--- a/.github/actions/build_image/action.yml
+++ b/.github/actions/build_image/action.yml
@@ -1,0 +1,39 @@
+name: build_image
+inputs:
+  ruby_version:
+    required: false
+    default: master
+  nightly:
+    required: false
+    default: false
+  image_version_suffix:
+    required: false
+    default: ''
+  ubuntu_version:
+    required: false
+    default: focal
+  tag_suffix:
+    required: false
+    default: ''
+  target:
+    required: false
+    default: ruby
+  latest_tag:
+    required: false
+    default: 'false'
+runs:
+  using: composite
+  steps:
+  - name: Build docker image
+    run: |-
+      rake docker:build ruby_version=${{ inputs.ruby_version }} \
+                        ubuntu_version=${{ inputs.ubuntu_version }} \
+                        image_version_suffix=${{ inputs.image_version_suffix }} \
+                        ${{ inputs.nightly }}nightly=yes${{ inputs.nightly }} \
+                        tag_suffix=${{ inputs.tag_suffix }} \
+                        target=${{ inputs.target }} \
+                        latest_tag=${{ inputs.latest_tag }}
+    shell: bash
+  - name: List images
+    run: docker images
+    shell: bash

--- a/.github/actions/push_image/action.yml
+++ b/.github/actions/push_image/action.yml
@@ -1,0 +1,33 @@
+name: push_image
+inputs:
+  ruby_version:
+    required: false
+    default: master
+  nightly:
+    required: false
+    default: false
+  image_version_suffix:
+    required: false
+    default: ''
+  ubuntu_version:
+    required: false
+    default: focal
+  tag_suffix:
+    required: false
+    default: ''
+  latest_tag:
+    required: false
+    default: 'false'
+runs:
+  using: composite
+  steps:
+  - name: Push docker image to rubylang
+    run: |-
+      echo $DOCKER_PASS | docker login -u $DOCKER_USER --password-stdin
+      rake docker:push ruby_version=${{ inputs.ruby_version }} \
+                       ubuntu_version=${{ inputs.ubuntu_version }} \
+                       image_version_suffix=${{ inputs.image_version_suffix }} \
+                       ${{ inputs.nightly }}nightly=yes${{ inputs.nightly }} \
+                       tag_suffix=${{ inputs.tag_suffix }} \
+                       latest_tag=${{ inputs.latest_tag }}
+    shell: bash

--- a/.github/actions/push_image_by_tag/action.yml
+++ b/.github/actions/push_image_by_tag/action.yml
@@ -1,0 +1,24 @@
+name: push_image_by_tag
+inputs:
+  push_tags:
+    required: false
+runs:
+  using: composite
+  steps:
+  - name: Push docker image to rubylang
+    run: |-
+      echo $DOCKER_PASS | docker login -u $DOCKER_USER --password-stdin
+      push_tags="${{ inputs.push_tags }}"
+      for tag in $push_tags; do
+        docker push rubylang/ruby:$tag
+      done
+    shell: bash
+  - name: Push docker image to ghcr.io/ruby
+    run: |-
+      echo $GHCR_ACCESS_TOKEN | docker login ghcr.io -u $GITHUB_USER --password-stdin
+      push_tags="${{ inputs.push_tags }}"
+      for tag in $push_tags; do
+        docker tag rubylang/ruby:$tag ghcr.io/ruby/ruby:$tag
+        docker push ghcr.io/ruby/ruby:$tag
+      done
+    shell: bash

--- a/.github/actions/push_image_by_tag/action.yml
+++ b/.github/actions/push_image_by_tag/action.yml
@@ -15,7 +15,7 @@ runs:
     shell: bash
   - name: Push docker image to ghcr.io/ruby
     run: |-
-      echo $GHCR_ACCESS_TOKEN | docker login ghcr.io -u $GITHUB_USER --password-stdin
+      echo $GHCR_ACCESS_TOKEN | docker login ghcr.io -u $GHCR_USER --password-stdin
       push_tags="${{ inputs.push_tags }}"
       for tag in $push_tags; do
         docker tag rubylang/ruby:$tag ghcr.io/ruby/ruby:$tag

--- a/.github/workflows/build_multiarch.yml
+++ b/.github/workflows/build_multiarch.yml
@@ -11,10 +11,10 @@ on:
         default: jammy
 
 env:
-  DOCKER_PASS: xxxxCD0o
-  DOCKER_USER: xxxxkn
-  GHCR_ACCESS_TOKEN: xxxxnzJy
-  GITHUB_USER: xxxxkn
+  DOCKER_USER: ${{ secrets.DOCKER_USER }}
+  DOCKER_PASS: ${{ secrets.DOCKER_PASS }}
+  GITHUB_USER: ${{ secrets.GITHUB_USER }}
+  GHCR_ACCESS_TOKEN: ${{ secrets.GHCR_ACCESS_TOKEN }}
 
 jobs:
   build_amd64:

--- a/.github/workflows/build_multiarch.yml
+++ b/.github/workflows/build_multiarch.yml
@@ -1,6 +1,9 @@
 name: ruby/ruby-docker-images/build_multiarch
 
 on:
+  schedule:
+    - cron: '0 */12 * * *'
+
   workflow_dispatch:
     inputs:
       ruby_version:

--- a/.github/workflows/build_multiarch.yml
+++ b/.github/workflows/build_multiarch.yml
@@ -13,7 +13,7 @@ on:
 env:
   DOCKER_USER: ${{ secrets.DOCKER_USER }}
   DOCKER_PASS: ${{ secrets.DOCKER_PASS }}
-  GITHUB_USER: ${{ secrets.GITHUB_USER }}
+  GHCR_USER: ${{ secrets.GHCR_USER }}
   GHCR_ACCESS_TOKEN: ${{ secrets.GHCR_ACCESS_TOKEN }}
 
 jobs:
@@ -174,7 +174,7 @@ jobs:
             echo $DOCKER_PASS | docker login -u $DOCKER_USER --password-stdin
             ;;
           xghcr.io/ruby)
-            echo $GHCR_ACCESS_TOKEN | docker login ghcr.io -u $GITHUB_USER --password-stdin
+            echo $GHCR_ACCESS_TOKEN | docker login ghcr.io -u $GHCR_USER --password-stdin
             ;;
           *)
             echo "ERROR: Unknown registry_name parameter: $registry_name" >&2
@@ -241,7 +241,7 @@ jobs:
             echo $DOCKER_PASS | docker login -u $DOCKER_USER --password-stdin
             ;;
           xghcr.io/ruby)
-            echo $GHCR_ACCESS_TOKEN | docker login ghcr.io -u $GITHUB_USER --password-stdin
+            echo $GHCR_ACCESS_TOKEN | docker login ghcr.io -u $GHCR_USER --password-stdin
             ;;
           *)
             echo "ERROR: Unknown registry_name parameter: $registry_name" >&2

--- a/.github/workflows/build_multiarch.yml
+++ b/.github/workflows/build_multiarch.yml
@@ -1,4 +1,5 @@
 name: ruby/ruby-docker-images/build_multiarch
+
 on:
   workflow_dispatch:
     inputs:
@@ -8,18 +9,23 @@ on:
       ubuntu_version:
         required: false
         default: jammy
+
 env:
   DOCKER_PASS: xxxxCD0o
   DOCKER_USER: xxxxkn
   GHCR_ACCESS_TOKEN: xxxxnzJy
   GITHUB_USER: xxxxkn
+
 jobs:
-  build:
+  build_amd64:
     if: !'scheduled_pipeline' == << pipeline.trigger_source >> && ${{ inputs.ruby_version }} && !'nightly' == ${{ inputs.ruby_version }}
+
     defaults:
       run:
         working-directory: "~/repo"
+
     runs-on: ubuntu-latest
+
     env:
       cppflags: "${{ env.cppflags }}"
       optflags: "${{ env.optflags }}"
@@ -38,8 +44,10 @@ jobs:
       optflags: ''
       cppflags: ''
       debugflags: ''
+
     steps:
     - uses: actions/checkout@v4.1.0
+
     - uses: "./.github/actions/build_image"
       if: "!${{ env.only_development }}"
       with:
@@ -49,6 +57,7 @@ jobs:
         ubuntu_version: "${{ env.ubuntu_version }}"
         tag_suffix: "${{ env.tag_suffix }}"
         latest_tag: 'true'
+
     - uses: "./.github/actions/build_image"
       with:
         ruby_version: "${{ env.ruby_version }}"
@@ -57,6 +66,7 @@ jobs:
         ubuntu_version: "${{ env.ubuntu_version }}"
         tag_suffix: "${{ env.tag_suffix }}"
         target: development
+
     - uses: "./.github/actions/push_image"
       if: "${{ env.push }}"
       with:
@@ -65,16 +75,21 @@ jobs:
         image_version_suffix: "${{ env.image_version_suffix }}${{ env.dev_suffix }}"
         ubuntu_version: "${{ env.ubuntu_version }}"
         tag_suffix: "${{ env.tag_suffix }}"
+
     - uses: "./.github/actions/push_image_by_tag"
       if: "${{ env.push_tags }}"
       with:
         push_tags: "${{ env.push_tags }}"
-  build_1:
+
+  build_arm64:
     if: !'scheduled_pipeline' == << pipeline.trigger_source >> && ${{ inputs.ruby_version }} && !'nightly' == ${{ inputs.ruby_version }}
+
     defaults:
       run:
         working-directory: "~/repo"
+
     runs-on: ubuntu-latest
+
     env:
       cppflags: "${{ env.cppflags }}"
       optflags: "${{ env.optflags }}"
@@ -93,8 +108,10 @@ jobs:
       optflags: ''
       cppflags: ''
       debugflags: ''
+
     steps:
     - uses: actions/checkout@v4.1.0
+
     - uses: "./.github/actions/build_image"
       if: "!${{ env.only_development }}"
       with:
@@ -104,6 +121,7 @@ jobs:
         ubuntu_version: "${{ env.ubuntu_version }}"
         tag_suffix: "${{ env.tag_suffix }}"
         latest_tag: 'true'
+
     - uses: "./.github/actions/build_image"
       with:
         ruby_version: "${{ env.ruby_version }}"
@@ -112,6 +130,7 @@ jobs:
         ubuntu_version: "${{ env.ubuntu_version }}"
         tag_suffix: "${{ env.tag_suffix }}"
         target: development
+
     - uses: "./.github/actions/push_image"
       if: "${{ env.push }}"
       with:
@@ -120,26 +139,34 @@ jobs:
         image_version_suffix: "${{ env.image_version_suffix }}${{ env.dev_suffix }}"
         ubuntu_version: "${{ env.ubuntu_version }}"
         tag_suffix: "${{ env.tag_suffix }}"
+
     - uses: "./.github/actions/push_image_by_tag"
       if: "${{ env.push_tags }}"
       with:
         push_tags: "${{ env.push_tags }}"
+
   deploy_multiarch:
     if: !'scheduled_pipeline' == << pipeline.trigger_source >> && ${{ inputs.ruby_version }} && !'nightly' == ${{ inputs.ruby_version }}
+
     defaults:
       run:
         working-directory: "~/repo"
+
     runs-on: ubuntu-latest
+
     needs:
     - build_amd64
     - build_arm64
+
     env:
       ruby_version: "${{ inputs.ruby_version }}"
       ubuntu_version: "${{ inputs.ubuntu_version }}"
       executor: amd64
       registry_name: rubylang
+
     steps:
     - uses: actions/checkout@v4.1.0
+
     - name: Login to ${{ env.registry_name }}
       run: |-
         case x"${{ env.registry_name }}" in
@@ -154,6 +181,7 @@ jobs:
             exit 1
             ;;
         esac
+
     - name: Create manifest for ${{ env.registry_name }}
       run: |-
         rake docker:manifest:create \
@@ -170,6 +198,7 @@ jobs:
              architectures="amd64 arm64" \
              image_version_suffix=-dev \
              manifest_suffix=${{ github.sha }}
+
     - name: Push manifest to ${{ env.registry_name }}
       run: |-
         rake docker:manifest:push \
@@ -182,22 +211,29 @@ jobs:
              ruby_version="${{ env.ruby_version }}" \
              ubuntu_version="${{ env.ubuntu_version }}" \
              image_version_suffix=-dev
-  deploy_multiarch_1:
+
+  deploy_multiarch_ghcr:
     if: !'scheduled_pipeline' == << pipeline.trigger_source >> && ${{ inputs.ruby_version }} && !'nightly' == ${{ inputs.ruby_version }}
+
     defaults:
       run:
         working-directory: "~/repo"
+
     runs-on: ubuntu-latest
+
     needs:
     - build_amd64
     - build_arm64
+
     env:
       ruby_version: "${{ inputs.ruby_version }}"
       ubuntu_version: "${{ inputs.ubuntu_version }}"
       executor: amd64
       registry_name: ghcr.io/ruby
+
     steps:
     - uses: actions/checkout@v4.1.0
+
     - name: Login to ${{ env.registry_name }}
       run: |-
         case x"${{ env.registry_name }}" in
@@ -212,6 +248,7 @@ jobs:
             exit 1
             ;;
         esac
+
     - name: Create manifest for ${{ env.registry_name }}
       run: |-
         rake docker:manifest:create \
@@ -228,6 +265,7 @@ jobs:
              architectures="amd64 arm64" \
              image_version_suffix=-dev \
              manifest_suffix=${{ github.sha }}
+
     - name: Push manifest to ${{ env.registry_name }}
       run: |-
         rake docker:manifest:push \

--- a/.github/workflows/build_multiarch.yml
+++ b/.github/workflows/build_multiarch.yml
@@ -1,0 +1,242 @@
+name: ruby/ruby-docker-images/build_multiarch
+on:
+  workflow_dispatch:
+    inputs:
+      ruby_version:
+        required: true
+        description: '"master" or version nunmber ("3.1.2")'
+      ubuntu_version:
+        required: false
+        default: jammy
+env:
+  DOCKER_PASS: xxxxCD0o
+  DOCKER_USER: xxxxkn
+  GHCR_ACCESS_TOKEN: xxxxnzJy
+  GITHUB_USER: xxxxkn
+jobs:
+  build:
+    if: !'scheduled_pipeline' == << pipeline.trigger_source >> && ${{ inputs.ruby_version }} && !'nightly' == ${{ inputs.ruby_version }}
+    defaults:
+      run:
+        working-directory: "~/repo"
+    runs-on: ubuntu-latest
+    env:
+      cppflags: "${{ env.cppflags }}"
+      optflags: "${{ env.optflags }}"
+      nightly: false
+      push: false
+      ubuntu_version: "${{ inputs.ubuntu_version }}"
+      ruby_version: "${{ inputs.ruby_version }}"
+      executor: amd64
+      image_version_suffix: ''
+      tag_suffix: "-amd64-${{ github.sha }}"
+      push_tags: |
+        ${{ inputs.ruby_version }}-${{ inputs.ubuntu_version }}-amd64-${{ github.sha }}
+        ${{ inputs.ruby_version }}-dev-${{ inputs.ubuntu_version }}-amd64-${{ github.sha }}
+      dev_suffix: "-dev"
+      only_development: false
+      optflags: ''
+      cppflags: ''
+      debugflags: ''
+    steps:
+    - uses: actions/checkout@v4.1.0
+    - uses: "./.github/actions/build_image"
+      if: "!${{ env.only_development }}"
+      with:
+        ruby_version: "${{ env.ruby_version }}"
+        nightly: "${{ env.nightly }}"
+        image_version_suffix: "${{ env.image_version_suffix }}"
+        ubuntu_version: "${{ env.ubuntu_version }}"
+        tag_suffix: "${{ env.tag_suffix }}"
+        latest_tag: 'true'
+    - uses: "./.github/actions/build_image"
+      with:
+        ruby_version: "${{ env.ruby_version }}"
+        nightly: "${{ env.nightly }}"
+        image_version_suffix: "${{ env.image_version_suffix }}${{ env.dev_suffix }}"
+        ubuntu_version: "${{ env.ubuntu_version }}"
+        tag_suffix: "${{ env.tag_suffix }}"
+        target: development
+    - uses: "./.github/actions/push_image"
+      if: "${{ env.push }}"
+      with:
+        ruby_version: "${{ env.ruby_version }}"
+        nightly: "${{ env.nightly }}"
+        image_version_suffix: "${{ env.image_version_suffix }}${{ env.dev_suffix }}"
+        ubuntu_version: "${{ env.ubuntu_version }}"
+        tag_suffix: "${{ env.tag_suffix }}"
+    - uses: "./.github/actions/push_image_by_tag"
+      if: "${{ env.push_tags }}"
+      with:
+        push_tags: "${{ env.push_tags }}"
+  build_1:
+    if: !'scheduled_pipeline' == << pipeline.trigger_source >> && ${{ inputs.ruby_version }} && !'nightly' == ${{ inputs.ruby_version }}
+    defaults:
+      run:
+        working-directory: "~/repo"
+    runs-on: ubuntu-latest
+    env:
+      cppflags: "${{ env.cppflags }}"
+      optflags: "${{ env.optflags }}"
+      nightly: false
+      push: false
+      ubuntu_version: "${{ inputs.ubuntu_version }}"
+      ruby_version: "${{ inputs.ruby_version }}"
+      executor: arm64
+      image_version_suffix: ''
+      tag_suffix: "-arm64-${{ github.sha }}"
+      push_tags: |
+        ${{ inputs.ruby_version }}-${{ inputs.ubuntu_version }}-arm64-${{ github.sha }}
+        ${{ inputs.ruby_version }}-dev-${{ inputs.ubuntu_version }}-arm64-${{ github.sha }}
+      dev_suffix: "-dev"
+      only_development: false
+      optflags: ''
+      cppflags: ''
+      debugflags: ''
+    steps:
+    - uses: actions/checkout@v4.1.0
+    - uses: "./.github/actions/build_image"
+      if: "!${{ env.only_development }}"
+      with:
+        ruby_version: "${{ env.ruby_version }}"
+        nightly: "${{ env.nightly }}"
+        image_version_suffix: "${{ env.image_version_suffix }}"
+        ubuntu_version: "${{ env.ubuntu_version }}"
+        tag_suffix: "${{ env.tag_suffix }}"
+        latest_tag: 'true'
+    - uses: "./.github/actions/build_image"
+      with:
+        ruby_version: "${{ env.ruby_version }}"
+        nightly: "${{ env.nightly }}"
+        image_version_suffix: "${{ env.image_version_suffix }}${{ env.dev_suffix }}"
+        ubuntu_version: "${{ env.ubuntu_version }}"
+        tag_suffix: "${{ env.tag_suffix }}"
+        target: development
+    - uses: "./.github/actions/push_image"
+      if: "${{ env.push }}"
+      with:
+        ruby_version: "${{ env.ruby_version }}"
+        nightly: "${{ env.nightly }}"
+        image_version_suffix: "${{ env.image_version_suffix }}${{ env.dev_suffix }}"
+        ubuntu_version: "${{ env.ubuntu_version }}"
+        tag_suffix: "${{ env.tag_suffix }}"
+    - uses: "./.github/actions/push_image_by_tag"
+      if: "${{ env.push_tags }}"
+      with:
+        push_tags: "${{ env.push_tags }}"
+  deploy_multiarch:
+    if: !'scheduled_pipeline' == << pipeline.trigger_source >> && ${{ inputs.ruby_version }} && !'nightly' == ${{ inputs.ruby_version }}
+    defaults:
+      run:
+        working-directory: "~/repo"
+    runs-on: ubuntu-latest
+    needs:
+    - build_amd64
+    - build_arm64
+    env:
+      ruby_version: "${{ inputs.ruby_version }}"
+      ubuntu_version: "${{ inputs.ubuntu_version }}"
+      executor: amd64
+      registry_name: rubylang
+    steps:
+    - uses: actions/checkout@v4.1.0
+    - name: Login to ${{ env.registry_name }}
+      run: |-
+        case x"${{ env.registry_name }}" in
+          xrubylang)
+            echo $DOCKER_PASS | docker login -u $DOCKER_USER --password-stdin
+            ;;
+          xghcr.io/ruby)
+            echo $GHCR_ACCESS_TOKEN | docker login ghcr.io -u $GITHUB_USER --password-stdin
+            ;;
+          *)
+            echo "ERROR: Unknown registry_name parameter: $registry_name" >&2
+            exit 1
+            ;;
+        esac
+    - name: Create manifest for ${{ env.registry_name }}
+      run: |-
+        rake docker:manifest:create \
+             registry_name="${{ env.registry_name }}" \
+             ruby_version="${{ env.ruby_version }}" \
+             ubuntu_version="${{ env.ubuntu_version }}" \
+             architectures="amd64 arm64" \
+             manifest_suffix=${{ github.sha }} \
+             latest_tag=true
+        rake docker:manifest:create \
+             registry_name="${{ env.registry_name }}" \
+             ruby_version="${{ env.ruby_version }}" \
+             ubuntu_version="${{ env.ubuntu_version }}" \
+             architectures="amd64 arm64" \
+             image_version_suffix=-dev \
+             manifest_suffix=${{ github.sha }}
+    - name: Push manifest to ${{ env.registry_name }}
+      run: |-
+        rake docker:manifest:push \
+             registry_name="${{ env.registry_name }}" \
+             ruby_version="${{ env.ruby_version }}" \
+             ubuntu_version="${{ env.ubuntu_version }}" \
+             latest_tag=true
+        rake docker:manifest:push \
+             registry_name="${{ env.registry_name }}" \
+             ruby_version="${{ env.ruby_version }}" \
+             ubuntu_version="${{ env.ubuntu_version }}" \
+             image_version_suffix=-dev
+  deploy_multiarch_1:
+    if: !'scheduled_pipeline' == << pipeline.trigger_source >> && ${{ inputs.ruby_version }} && !'nightly' == ${{ inputs.ruby_version }}
+    defaults:
+      run:
+        working-directory: "~/repo"
+    runs-on: ubuntu-latest
+    needs:
+    - build_amd64
+    - build_arm64
+    env:
+      ruby_version: "${{ inputs.ruby_version }}"
+      ubuntu_version: "${{ inputs.ubuntu_version }}"
+      executor: amd64
+      registry_name: ghcr.io/ruby
+    steps:
+    - uses: actions/checkout@v4.1.0
+    - name: Login to ${{ env.registry_name }}
+      run: |-
+        case x"${{ env.registry_name }}" in
+          xrubylang)
+            echo $DOCKER_PASS | docker login -u $DOCKER_USER --password-stdin
+            ;;
+          xghcr.io/ruby)
+            echo $GHCR_ACCESS_TOKEN | docker login ghcr.io -u $GITHUB_USER --password-stdin
+            ;;
+          *)
+            echo "ERROR: Unknown registry_name parameter: $registry_name" >&2
+            exit 1
+            ;;
+        esac
+    - name: Create manifest for ${{ env.registry_name }}
+      run: |-
+        rake docker:manifest:create \
+             registry_name="${{ env.registry_name }}" \
+             ruby_version="${{ env.ruby_version }}" \
+             ubuntu_version="${{ env.ubuntu_version }}" \
+             architectures="amd64 arm64" \
+             manifest_suffix=${{ github.sha }} \
+             latest_tag=true
+        rake docker:manifest:create \
+             registry_name="${{ env.registry_name }}" \
+             ruby_version="${{ env.ruby_version }}" \
+             ubuntu_version="${{ env.ubuntu_version }}" \
+             architectures="amd64 arm64" \
+             image_version_suffix=-dev \
+             manifest_suffix=${{ github.sha }}
+    - name: Push manifest to ${{ env.registry_name }}
+      run: |-
+        rake docker:manifest:push \
+             registry_name="${{ env.registry_name }}" \
+             ruby_version="${{ env.ruby_version }}" \
+             ubuntu_version="${{ env.ubuntu_version }}" \
+             latest_tag=true
+        rake docker:manifest:push \
+             registry_name="${{ env.registry_name }}" \
+             ruby_version="${{ env.ruby_version }}" \
+             ubuntu_version="${{ env.ubuntu_version }}" \
+             image_version_suffix=-dev

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -13,7 +13,7 @@ on:
 env:
   DOCKER_USER: ${{ secrets.DOCKER_USER }}
   DOCKER_PASS: ${{ secrets.DOCKER_PASS }}
-  GITHUB_USER: ${{ secrets.GITHUB_USER }}
+  GHCR_USER: ${{ secrets.GHCR_USER }}
   GHCR_ACCESS_TOKEN: ${{ secrets.GHCR_ACCESS_TOKEN }}
 
 jobs:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -11,10 +11,10 @@ on:
         default: jammy
 
 env:
-  DOCKER_PASS: xxxxCD0o
-  DOCKER_USER: xxxxkn
-  GHCR_ACCESS_TOKEN: xxxxnzJy
-  GITHUB_USER: xxxxkn
+  DOCKER_USER: ${{ secrets.DOCKER_USER }}
+  DOCKER_PASS: ${{ secrets.DOCKER_PASS }}
+  GITHUB_USER: ${{ secrets.GITHUB_USER }}
+  GHCR_ACCESS_TOKEN: ${{ secrets.GHCR_ACCESS_TOKEN }}
 
 jobs:
   build_jammy:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,175 @@
+name: ruby/ruby-docker-images/nightly
+on:
+  workflow_dispatch:
+    inputs:
+      ruby_version:
+        required: true
+        description: '"master" or version nunmber ("3.1.2")'
+      ubuntu_version:
+        required: false
+        default: jammy
+env:
+  DOCKER_PASS: xxxxCD0o
+  DOCKER_USER: xxxxkn
+  GHCR_ACCESS_TOKEN: xxxxnzJy
+  GITHUB_USER: xxxxkn
+jobs:
+  build:
+    if: 'nightly' == ${{ inputs.ruby_version }}
+    defaults:
+      run:
+        working-directory: "~/repo"
+    runs-on: ubuntu-latest
+    env:
+      cppflags: "${{ env.cppflags }}"
+      optflags: "${{ env.optflags }}"
+      nightly: true
+      push: true
+      ubuntu_version: jammy
+      ruby_version: master
+      executor: amd64
+      image_version_suffix: ''
+      tag_suffix: ''
+      push_tags: ''
+      dev_suffix: "-dev"
+      only_development: true
+      optflags: ''
+      cppflags: ''
+      debugflags: ''
+    steps:
+    - uses: actions/checkout@v4.1.0
+    - uses: "./.github/actions/build_image"
+      if: "!${{ env.only_development }}"
+      with:
+        ruby_version: "${{ env.ruby_version }}"
+        nightly: "${{ env.nightly }}"
+        image_version_suffix: "${{ env.image_version_suffix }}"
+        ubuntu_version: "${{ env.ubuntu_version }}"
+        tag_suffix: "${{ env.tag_suffix }}"
+        latest_tag: 'true'
+    - uses: "./.github/actions/build_image"
+      with:
+        ruby_version: "${{ env.ruby_version }}"
+        nightly: "${{ env.nightly }}"
+        image_version_suffix: "${{ env.image_version_suffix }}${{ env.dev_suffix }}"
+        ubuntu_version: "${{ env.ubuntu_version }}"
+        tag_suffix: "${{ env.tag_suffix }}"
+        target: development
+    - uses: "./.github/actions/push_image"
+      if: "${{ env.push }}"
+      with:
+        ruby_version: "${{ env.ruby_version }}"
+        nightly: "${{ env.nightly }}"
+        image_version_suffix: "${{ env.image_version_suffix }}${{ env.dev_suffix }}"
+        ubuntu_version: "${{ env.ubuntu_version }}"
+        tag_suffix: "${{ env.tag_suffix }}"
+    - uses: "./.github/actions/push_image_by_tag"
+      if: "${{ env.push_tags }}"
+      with:
+        push_tags: "${{ env.push_tags }}"
+  build_1:
+    if: 'nightly' == ${{ inputs.ruby_version }}
+    defaults:
+      run:
+        working-directory: "~/repo"
+    runs-on: ubuntu-latest
+    env:
+      cppflags: "${{ env.cppflags }}"
+      optflags: "${{ env.optflags }}"
+      nightly: true
+      push: true
+      ubuntu_version: focal
+      ruby_version: master
+      executor: amd64
+      image_version_suffix: ''
+      tag_suffix: ''
+      push_tags: ''
+      dev_suffix: "-dev"
+      only_development: true
+      optflags: ''
+      cppflags: ''
+      debugflags: ''
+    steps:
+    - uses: actions/checkout@v4.1.0
+    - uses: "./.github/actions/build_image"
+      if: "!${{ env.only_development }}"
+      with:
+        ruby_version: "${{ env.ruby_version }}"
+        nightly: "${{ env.nightly }}"
+        image_version_suffix: "${{ env.image_version_suffix }}"
+        ubuntu_version: "${{ env.ubuntu_version }}"
+        tag_suffix: "${{ env.tag_suffix }}"
+        latest_tag: 'true'
+    - uses: "./.github/actions/build_image"
+      with:
+        ruby_version: "${{ env.ruby_version }}"
+        nightly: "${{ env.nightly }}"
+        image_version_suffix: "${{ env.image_version_suffix }}${{ env.dev_suffix }}"
+        ubuntu_version: "${{ env.ubuntu_version }}"
+        tag_suffix: "${{ env.tag_suffix }}"
+        target: development
+    - uses: "./.github/actions/push_image"
+      if: "${{ env.push }}"
+      with:
+        ruby_version: "${{ env.ruby_version }}"
+        nightly: "${{ env.nightly }}"
+        image_version_suffix: "${{ env.image_version_suffix }}${{ env.dev_suffix }}"
+        ubuntu_version: "${{ env.ubuntu_version }}"
+        tag_suffix: "${{ env.tag_suffix }}"
+    - uses: "./.github/actions/push_image_by_tag"
+      if: "${{ env.push_tags }}"
+      with:
+        push_tags: "${{ env.push_tags }}"
+  build_2:
+    if: 'nightly' == ${{ inputs.ruby_version }}
+    defaults:
+      run:
+        working-directory: "~/repo"
+    runs-on: ubuntu-latest
+    env:
+      cppflags: "${{ env.cppflags }}"
+      optflags: "${{ env.optflags }}"
+      nightly: true
+      push: true
+      ubuntu_version: jammy
+      ruby_version: master
+      executor: amd64
+      image_version_suffix: "-debug"
+      tag_suffix: ''
+      push_tags: ''
+      dev_suffix: "-dev"
+      only_development: true
+      optflags: ''
+      cppflags: ''
+      debugflags: ''
+    steps:
+    - uses: actions/checkout@v4.1.0
+    - uses: "./.github/actions/build_image"
+      if: "!${{ env.only_development }}"
+      with:
+        ruby_version: "${{ env.ruby_version }}"
+        nightly: "${{ env.nightly }}"
+        image_version_suffix: "${{ env.image_version_suffix }}"
+        ubuntu_version: "${{ env.ubuntu_version }}"
+        tag_suffix: "${{ env.tag_suffix }}"
+        latest_tag: 'true'
+    - uses: "./.github/actions/build_image"
+      with:
+        ruby_version: "${{ env.ruby_version }}"
+        nightly: "${{ env.nightly }}"
+        image_version_suffix: "${{ env.image_version_suffix }}${{ env.dev_suffix }}"
+        ubuntu_version: "${{ env.ubuntu_version }}"
+        tag_suffix: "${{ env.tag_suffix }}"
+        target: development
+    - uses: "./.github/actions/push_image"
+      if: "${{ env.push }}"
+      with:
+        ruby_version: "${{ env.ruby_version }}"
+        nightly: "${{ env.nightly }}"
+        image_version_suffix: "${{ env.image_version_suffix }}${{ env.dev_suffix }}"
+        ubuntu_version: "${{ env.ubuntu_version }}"
+        tag_suffix: "${{ env.tag_suffix }}"
+    - uses: "./.github/actions/push_image_by_tag"
+      if: "${{ env.push_tags }}"
+      with:
+        push_tags: "${{ env.push_tags }}"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,4 +1,5 @@
 name: ruby/ruby-docker-images/nightly
+
 on:
   workflow_dispatch:
     inputs:
@@ -8,18 +9,23 @@ on:
       ubuntu_version:
         required: false
         default: jammy
+
 env:
   DOCKER_PASS: xxxxCD0o
   DOCKER_USER: xxxxkn
   GHCR_ACCESS_TOKEN: xxxxnzJy
   GITHUB_USER: xxxxkn
+
 jobs:
-  build:
+  build_jammy:
     if: 'nightly' == ${{ inputs.ruby_version }}
+
     defaults:
       run:
         working-directory: "~/repo"
+
     runs-on: ubuntu-latest
+
     env:
       cppflags: "${{ env.cppflags }}"
       optflags: "${{ env.optflags }}"
@@ -36,8 +42,10 @@ jobs:
       optflags: ''
       cppflags: ''
       debugflags: ''
+
     steps:
     - uses: actions/checkout@v4.1.0
+
     - uses: "./.github/actions/build_image"
       if: "!${{ env.only_development }}"
       with:
@@ -47,6 +55,7 @@ jobs:
         ubuntu_version: "${{ env.ubuntu_version }}"
         tag_suffix: "${{ env.tag_suffix }}"
         latest_tag: 'true'
+
     - uses: "./.github/actions/build_image"
       with:
         ruby_version: "${{ env.ruby_version }}"
@@ -55,6 +64,7 @@ jobs:
         ubuntu_version: "${{ env.ubuntu_version }}"
         tag_suffix: "${{ env.tag_suffix }}"
         target: development
+
     - uses: "./.github/actions/push_image"
       if: "${{ env.push }}"
       with:
@@ -63,16 +73,21 @@ jobs:
         image_version_suffix: "${{ env.image_version_suffix }}${{ env.dev_suffix }}"
         ubuntu_version: "${{ env.ubuntu_version }}"
         tag_suffix: "${{ env.tag_suffix }}"
+
     - uses: "./.github/actions/push_image_by_tag"
       if: "${{ env.push_tags }}"
       with:
         push_tags: "${{ env.push_tags }}"
+
   build_1:
     if: 'nightly' == ${{ inputs.ruby_version }}
+
     defaults:
       run:
         working-directory: "~/repo"
+
     runs-on: ubuntu-latest
+
     env:
       cppflags: "${{ env.cppflags }}"
       optflags: "${{ env.optflags }}"
@@ -89,8 +104,10 @@ jobs:
       optflags: ''
       cppflags: ''
       debugflags: ''
+
     steps:
     - uses: actions/checkout@v4.1.0
+
     - uses: "./.github/actions/build_image"
       if: "!${{ env.only_development }}"
       with:
@@ -100,6 +117,7 @@ jobs:
         ubuntu_version: "${{ env.ubuntu_version }}"
         tag_suffix: "${{ env.tag_suffix }}"
         latest_tag: 'true'
+
     - uses: "./.github/actions/build_image"
       with:
         ruby_version: "${{ env.ruby_version }}"
@@ -108,6 +126,7 @@ jobs:
         ubuntu_version: "${{ env.ubuntu_version }}"
         tag_suffix: "${{ env.tag_suffix }}"
         target: development
+
     - uses: "./.github/actions/push_image"
       if: "${{ env.push }}"
       with:
@@ -116,16 +135,21 @@ jobs:
         image_version_suffix: "${{ env.image_version_suffix }}${{ env.dev_suffix }}"
         ubuntu_version: "${{ env.ubuntu_version }}"
         tag_suffix: "${{ env.tag_suffix }}"
+
     - uses: "./.github/actions/push_image_by_tag"
       if: "${{ env.push_tags }}"
       with:
         push_tags: "${{ env.push_tags }}"
-  build_2:
+
+  build_focal:
     if: 'nightly' == ${{ inputs.ruby_version }}
+
     defaults:
       run:
         working-directory: "~/repo"
+
     runs-on: ubuntu-latest
+
     env:
       cppflags: "${{ env.cppflags }}"
       optflags: "${{ env.optflags }}"
@@ -142,8 +166,10 @@ jobs:
       optflags: ''
       cppflags: ''
       debugflags: ''
+
     steps:
     - uses: actions/checkout@v4.1.0
+
     - uses: "./.github/actions/build_image"
       if: "!${{ env.only_development }}"
       with:
@@ -153,6 +179,7 @@ jobs:
         ubuntu_version: "${{ env.ubuntu_version }}"
         tag_suffix: "${{ env.tag_suffix }}"
         latest_tag: 'true'
+
     - uses: "./.github/actions/build_image"
       with:
         ruby_version: "${{ env.ruby_version }}"
@@ -161,6 +188,7 @@ jobs:
         ubuntu_version: "${{ env.ubuntu_version }}"
         tag_suffix: "${{ env.tag_suffix }}"
         target: development
+
     - uses: "./.github/actions/push_image"
       if: "${{ env.push }}"
       with:
@@ -169,6 +197,7 @@ jobs:
         image_version_suffix: "${{ env.image_version_suffix }}${{ env.dev_suffix }}"
         ubuntu_version: "${{ env.ubuntu_version }}"
         tag_suffix: "${{ env.tag_suffix }}"
+
     - uses: "./.github/actions/push_image_by_tag"
       if: "${{ env.push_tags }}"
       with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,6 +1,9 @@
 name: ruby/ruby-docker-images/nightly
 
 on:
+  schedule:
+    - cron: '0 */12 * * *'
+
   workflow_dispatch:
     inputs:
       ruby_version:


### PR DESCRIPTION
Pipeline migrated from [CircleCI](https://app.circleci.com/pipelines/github/ruby/ruby-docker-images) :tada:

## Manual steps

Perform the following steps to complete the migration:

### ruby/ruby-docker-images/nightly
- [ ] Ensure environment variable is updated: `DOCKER_PASS`
- [ ] Ensure environment variable is updated: `DOCKER_USER`
- [ ] Ensure environment variable is updated: `GHCR_ACCESS_TOKEN`
- [ ] Ensure environment variable is updated: `GITHUB_USER`

### ruby/ruby-docker-images/build_multiarch
- [ ] Ensure environment variable is updated: `DOCKER_PASS`
- [ ] Ensure environment variable is updated: `DOCKER_USER`
- [ ] Ensure environment variable is updated: `GHCR_ACCESS_TOKEN`
- [ ] Ensure environment variable is updated: `GITHUB_USER`