### PR TITLE
Use buildx when specified arm64

### DIFF
--- a/.github/actions/build_image/action.yml
+++ b/.github/actions/build_image/action.yml
@@ -21,13 +21,23 @@ inputs:
   latest_tag:
     required: false
     default: 'false'
+  arch:
+    required: false
+    default: linux/amd64
 runs:
   using: composite
   steps:
+  - name: Set up QEMU
+    uses: docker/setup-qemu-action@v1
+
+  - name: Set up Docker Buildx
+    uses: docker/setup-buildx-action@v1
+
   - name: Build docker image
     run: |-
       rake docker:build ruby_version=${{ inputs.ruby_version }} \
                         ubuntu_version=${{ inputs.ubuntu_version }} \
+                        arch=${{ inputs.arch }} \
                         image_version_suffix=${{ inputs.image_version_suffix }} \
                         ${{ inputs.nightly }}nightly=yes${{ inputs.nightly }} \
                         tag_suffix=${{ inputs.tag_suffix }} \

--- a/.github/workflows/build_multiarch.yml
+++ b/.github/workflows/build_multiarch.yml
@@ -88,7 +88,7 @@ jobs:
       run:
         working-directory: "~/repo"
 
-    runs-on: macos-arm-oss
+    runs-on: ubuntu-latest
 
     env:
       nightly: false
@@ -118,6 +118,7 @@ jobs:
         ubuntu_version: "${{ env.ubuntu_version }}"
         tag_suffix: "${{ env.tag_suffix }}"
         latest_tag: 'true'
+        arch: 'linux/arm64'
 
     - uses: "./.github/actions/build_image"
       with:

--- a/Rakefile
+++ b/Rakefile
@@ -188,6 +188,7 @@ namespace :docker do
     tag_suffix = ENV["tag_suffix"]
     tag = ENV["tag"] || ""
     target = ENV.fetch("target", "ruby")
+    arch = ENV.fetch("arch", "linux/amd64")
 
     ruby_version, tags = make_tags(ruby_version, version_suffix, tag_suffix)
     tags << "#{docker_image_name}:#{tag}" if !tag.empty?
@@ -211,7 +212,9 @@ namespace :docker do
       IO.write('tmp/ruby/.keep', '')
     end
 
-    sh 'docker', 'build', '-f', 'Dockerfile',
+    build_cmd_args = arch =~ /arm/ ? ['buildx', 'build', '--platform', arch] : ['build']
+
+    sh 'docker', *build_cmd_args, '-f', 'Dockerfile',
        *tags.map {|tag| ["-t", tag] }.flatten,
        *build_args.map {|arg| ["--build-arg", arg] }.flatten,
        '--target', target,


### PR DESCRIPTION
`marcos-arm-oss` runner didn't support `docker` command yet. We need to use `buildx` for arm64 build.