### PR TITLE
Added pkg-config for sqlite3-ruby

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -175,6 +175,7 @@ RUN set -ex && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
             build-essential \
+            pkg-config \
             curl \
             gdb \
             git \


### PR DESCRIPTION
`sqlite3-ruby` needs `pkg-config`


```
Building native extensions. This could take a while...
ERROR:  Error installing sqlite3:
        ERROR: Failed to build gem native extension.

    current directory: /usr/local/lib/ruby/gems/3.4.0+0/gems/sqlite3-1.7.2/ext/sqlite3
/usr/local/bin/ruby extconf.rb
Building sqlite3-ruby using packaged sqlite3.
Extracting sqlite-autoconf-3450100.tar.gz into tmp/x86_64-linux-gnu/ports/sqlite3/3.45.1... OK
Running 'configure' for sqlite3 3.45.1... OK
Running 'compile' for sqlite3 3.45.1... OK
Running 'install' for sqlite3 3.45.1... OK
Activating sqlite3 3.45.1 (from /usr/local/lib/ruby/gems/3.4.0+0/gems/sqlite3-1.7.2/ports/x86_64-linux-gnu/sqlite3/3.45.1)...
checking for pkg-config for /usr/local/lib/ruby/gems/3.4.0+0/gems/sqlite3-1.7.2/ports/x86_64-linux-gnu/sqlite3/3.45.1/lib/pkgconfig/sqlite3.pc... not found

Could not configure the build properly (pkg_config). Please install either the `pkg-config` utility or the `pkg-config` rubygem.

*** extconf.rb failed ***
```