### PR TITLE
Use /root directory to install BASERUBY

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ COPY tmp/ruby /usr/src/ruby
 COPY install_ruby.sh /tmp/
 
 RUN set -ex && \
-    RUBY_VERSION=3.2.3 /tmp/install_ruby.sh
+    RUBY_VERSION=3.2.3 PREFIX=/root /tmp/install_ruby.sh
 RUN apt purge -y --auto-remove ruby
 COPY tmp/ruby /usr/src/ruby
 
@@ -66,8 +66,7 @@ RUN set -ex && \
       echo 'update: --no-document'; \
     } >> /usr/local/etc/gemrc && \
     \
-    /tmp/install_ruby.sh
-
+    PATH=/root/bin:$PATH /tmp/install_ruby.sh
 
 ### ruby ###
 FROM ubuntu:$BASE_IMAGE_TAG AS ruby

--- a/install_ruby.sh
+++ b/install_ruby.sh
@@ -5,6 +5,7 @@ set -ex
 RUBY_VERSION=${RUBY_VERSION-2.6.0}
 RUBY_MAJOR=$(echo $RUBY_VERSION | sed -E 's/\.[0-9]+(-.*)?$//g')
 RUBYGEMS_VERSION=${RUBYGEMS_VERSION-3.2.3}
+PREFIX=${PREFIX-/usr/local}
 
 function get_released_ruby() {
   git clone --depth 1 https://github.com/ruby/www.ruby-lang.org.git /tmp/www
@@ -83,7 +84,7 @@ fi
   gnuArch=$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)
   configure_args=( \
     --build="$gnuArch" \
-    --prefix=/usr/local \
+    --prefix="$PREFIX" \
     --disable-install-doc \
     --enable-shared \
     --enable-yjit
@@ -122,4 +123,5 @@ fi
 rm -fr /usr/src/ruby /root/.gem/
 
 # rough smoke test
+export PATH=$PREFIX/bin:$PATH
 (cd && ruby --version && gem --version && bundle --version)


### PR DESCRIPTION
I install Ruby 3.2 as BASERUBY at https://github.com/ruby/ruby-docker-images/pull/80

BASERUBY uses same prefix for final image. So, we have some of garbage from BASERUBY at https://github.com/ruby/ruby-docker-images/issues/78#issuecomment-1958582794

I change to use different directory for BASERUBY.