### PR TITLE
Don't stop all in-progress jobs if any matrix job fails.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,7 @@ jobs:
     name: ${{ github.event.inputs.RUBY_VERSION }}-${{ matrix.ubuntu_version }}-${{ github.event.inputs.ARCH }}
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         ubuntu_version:
           - jammy

--- a/.github/workflows/build_multiarch.yml
+++ b/.github/workflows/build_multiarch.yml
@@ -17,6 +17,7 @@ on:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         dev_suffix: [ '', '-dev' ]
         arch: ['amd64', 'arm64']

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         os: [jammy, focal]
         debug: ['', '-debug']


### PR DESCRIPTION
If some job is failed, we can't build and push all images. 

https://github.com/ruby/ruby-docker-images/actions/runs/9001512315 

We should try to build other images.