### PR TITLE
Use the workflow run ID for suffix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
     env:
       push: false
       ubuntu_version: "${{ matrix.ubuntu_version }}"
-      tag_suffix: "-${{ matrix.arch }}-${{ github.sha }}"
+      tag_suffix: "-${{ matrix.arch }}-${{ github.run_id }}"
       push_tags: ${{ github.event.inputs.ruby_version || github.event.client_payload.ruby_version || 'master' }}${{ matrix.debug_suffix }}${{ matrix.dev_suffix }}-${{ matrix.ubuntu_version }}-${{ matrix.arch }}-${{ github.sha }}
       dev_suffix: ${{ matrix.dev_suffix }}
       debug_suffix: ${{ matrix.debug_suffix }}
@@ -148,7 +148,7 @@ jobs:
              ruby_version="${{ env.ruby_version }}" \
              ubuntu_version="${{ matrix.ubuntu_version }}" \
              architectures="amd64 arm64" \
-             manifest_suffix=${{ github.sha }} \
+             manifest_suffix=${{ github.run_id }} \
              image_version_suffix=${{ matrix.image_version_suffix }}
 
     - name: Push manifest to ${{ matrix.registry_name }}

--- a/Rakefile
+++ b/Rakefile
@@ -300,6 +300,7 @@ namespace :docker do
       _, tags = make_tags(ruby_version, image_version_suffix)
 
       amend_args = architectures.map {|arch|
+        # "-#{arch}-#{manifest_suffix}" should match `tag_suffix` on `docker:build`
         manifest_name = "#{tags[0]}-#{arch}"
         manifest_name = "#{manifest_name}-#{manifest_suffix}" if manifest_suffix
         ['--amend', manifest_name]


### PR DESCRIPTION
This PR changes the tags created by `rake docker:push` to use `${{ github.run_id }}` instead of `${{ github.sha }}`.

Currently, it uses the `${{ github.sha }}` of `ruby/docker-images` as a suffix, which doesn't change across different workflow runs. When multiple workflow runs are created using `workflow_dispatch` at the same time, they could corrupt tags created by different runs. To isolate the tag namespace for each workflow run, it uses `${{ github.run_id }}` as a suffix instead of `${{ github.sha }}`.

We could use both in the suffix like `${{ github.sha }}-${{ github.run_id }}` for extra safety, but I also thought having non-`ruby/ruby` sha in tags seemed confusing by itself, so I decided to just replace it.