### PR TITLE
Allow overriding SHA for ruby_version=master

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,9 +14,13 @@ on:
         required: true
         default: master
         description: '"master" or version nunmber ("3.1.2")'
+      ruby_sha:
+        required: false
+        description: 'optional: override sha for ruby_version "master"'
 
 env:
   ruby_version: ${{ github.event.inputs.ruby_version || github.event.client_payload.ruby_version || 'master' }}
+  ruby_sha: ${{ github.event.inputs.ruby_sha || github.event.client_payload.ruby_sha || '' }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:

--- a/Rakefile
+++ b/Rakefile
@@ -232,7 +232,7 @@ namespace :docker do
 
   def make_tags(ruby_version, version_suffix=nil, tag_suffix=nil)
     if ruby_version == "master"
-      commit_hash = get_ruby_master_head_hash
+      commit_hash = ENV.fetch("ruby_sha", "").empty? ? get_ruby_master_head_hash : ENV.fetch("ruby_sha")
       commit_date = get_date_at_commit(commit_hash).then { |t| "%04d%02d%02d" % [t.year, t.month, t.day] }
       ruby_version = "master:#{commit_hash}"
       tags = ["master#{version_suffix}", "master#{version_suffix}-#{commit_hash}", "master#{version_suffix}-#{commit_date}"]


### PR DESCRIPTION
This PR adds `ruby_sha` parameter for `workflow_dispatch`.

The code `/\Amaster(?::([\da-f]+))?\z/ =~ ruby_version` seems to imply that `master:{sha}` works as a `ruby_version`, but the current workflow would then take it as part of the tag name, making it an invalid tag name. So the `master:{sha}` syntax doesn't really work today.

To keep using `master` as a fragment of the tag name and override the sha at the same time, you need to use a separate input for specifying a sha.