### PR TITLE
Add libatomic to the Containerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ RUN set -ex && \
             gcc \
             git \
             g++ \
+            libatomic1 \
             libffi-dev \
             libgdbm-dev \
             libgmp-dev \
@@ -77,6 +78,7 @@ RUN set -ex && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
             ca-certificates \
+            libaatomic1 \
             libffi-dev \
             libgdbm-dev \
             libgmp-dev \


### PR DESCRIPTION
Latest containers since 2025-11-21 have been building with broken Ruby.

```
Failed to run `docker run --rm ghcr.io/ruby/ruby:master-20251123 ruby -e print RUBY_REVISION`:
+ docker run --rm ghcr.io/ruby/ruby:master-20251122 ruby -e print RUBY_REVISION ruby: error while loading shared libraries: libatomic.so.1: cannot open shared object file: No such file or directory
```

Since [this commit](https://github.com/ruby/ruby/commit/d3b6f835d565ec1590059773fc87589ddf8adc37) introduces an extra check for libatomic

