### PR TITLE
Check if the image built is working before pushing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,6 +91,18 @@ jobs:
     - name: List images
       run: docker images
 
+    - name: Verify RUBY_REVISION in built image
+      run: |-
+        push_tags="${{ env.push_tags }}"
+        for tag in $push_tags; do
+          echo "Verifying rubylang/ruby:$tag"
+          if ! docker run --rm rubylang/ruby:$tag ruby -e 'print RUBY_REVISION'; then
+            echo "ERROR: Failed to extract RUBY_REVISION from rubylang/ruby:$tag"
+            exit 1
+          fi
+          echo ""
+        done
+
     - name: Push docker image to rubylang
       if: "${{ env.push_tags }}"
       run: |-


### PR DESCRIPTION
A few times in the past the ruby image build in this project wasn't a valid Ruby.

To avoid that problem we should fail and report instead of pushing to the repository.