### PR TITLE
Add "ruby -v" as a build step to verify successful image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -157,6 +157,8 @@ COPY --from=build \
      /usr/local/share/man/man1/*.* \
      /usr/local/share/man/man1/
 
+# Verify that the built/copied ruby can at least run (has necessary OS dependencies, etc).
+RUN /usr/local/bin/ruby -v
 
 ### development ###
 FROM ruby AS development


### PR DESCRIPTION
Successfully fails with current libatomic issue:
https://github.com/ruby/docker-images/actions/runs/19645428767/job/56259384552?pr=146#step:3:6185
```
#26 [ruby 14/14] RUN /usr/local/bin/ruby -v
#26 0.142 /usr/local/bin/ruby: error while loading shared libraries: libatomic.so.1: cannot open shared object file: No such file or directory
#26 ERROR: process "/bin/sh -c /usr/local/bin/ruby -v" did not complete successfully: exit code: 127
```