### PR TITLE
Fix incorrect redirection

### DIFF
--- a/install_ruby.sh
+++ b/install_ruby.sh
@@ -39,7 +39,7 @@ case $RUBY_VERSION in
   *)
     read RUBY_DOWNLOAD_URI RUBY_DOWNLOAD_SHA256 < <(get_released_ruby $RUBY_VERSION)
     if test -z "$RUBY_DOWNLOAD_URI"; then
-      echo "Unsupported RUBY_VERSION ($RUBY_VERSION)" >2
+      echo "Unsupported RUBY_VERSION ($RUBY_VERSION)" >&2
       exit 1
     fi
     echo $RUBY_DOWNLOAD_URI


### PR DESCRIPTION
It seems the intention was to output to stderr, so this commit adjusts it accordingly.
In the current version, it outputs to the file named `2`, which is likely incorrect.