### PR TITLE
Remove a duplicated `COPY` directive

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -113,9 +113,6 @@ RUN set -ex && \
 RUN mkdir -p /usr/local/etc
 
 COPY --from=build \
-     /usr/local/etc/gemrc /usr/local/etc
-
-COPY --from=build \
      /usr/local/bin/bundle \
      /usr/local/bin/bundler \
      /usr/local/bin/erb \


### PR DESCRIPTION
`COPY --from=build /usr/local/etc/gemrc /usr/local/etc` is called twice, so this commit removes one of them.