### PR TITLE
Remove an unnecessary file

### DIFF
--- a/ruby_build_deps.txt
+++ b/ruby_build_deps.txt
@@ -1,5 +1,0 @@
-dpkg-dev
-ruby
-wget
-xz-utils
-rustc


### PR DESCRIPTION
It seems the `ruby_build_deps.txt` file is no longer used.