### PR TITLE
Tweak the usage of `ENV`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,8 @@ FROM ghcr.io/ruby/ubuntu:$BASE_IMAGE_TAG AS build
 ARG BASE_IMAGE_TAG
 ARG RUBY_VERSION
 
-ENV LANG C.UTF-8
-ENV DEBIAN_FRONTEND noninteractive
+ENV LANG=C.UTF-8 \
+    DEBIAN_FRONTEND=noninteractive
 
 RUN set -ex && \
     apt-get update && \
@@ -70,8 +70,8 @@ ARG BASE_IMAGE_TAG
 ARG RUBY_VERSION
 ARG RUBY_SO_SUFFIX
 
-ENV LANG C.UTF-8
-ENV DEBIAN_FRONTEND noninteractive
+ENV LANG=C.UTF-8 \
+    DEBIAN_FRONTEND=noninteractive
 
 RUN set -ex && \
     apt-get update && \


### PR DESCRIPTION
This makes it use `ENV` with `=` separators.

ref: https://docs.docker.com/reference/dockerfile/#env
> The alternative syntax is supported for backward compatibility, but discouraged for the reasons outlined above, and may be removed in a future release.