### PR TITLE
Store the built Ruby commit sha in the github env

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -153,7 +153,7 @@ jobs:
 
     # Make sure the sha of "master-{sha}" tags agrees with the RUBY_REVISION in the image
     - name: Extract ruby_sha
-      run: echo "ruby_sha=$(docker run "$docker_image")" >> "$GITHUB_ENV"
+      run: echo "ruby_sha=$(docker run "$docker_image" ruby -e 'puts RUBY_REVISION')" >> "$GITHUB_ENV"
       env:
         # In docker:manifest:create:
         #   tags = ["master#{version_suffix}", ...]                                                       #=> "master${{ matrix.image_version_suffix }}"


### PR DESCRIPTION
Previously we expected "docker run image" to return the ruby sha but it does not.

When we build the tags for the manifest we try and fetch the commit hash from the environment, falling back to getting the latest commit from master if it's empty (which it will be in this case).

So this means there is a window between when the image builds happen and when the deploy_multiarch job happens where if HEAD advances then a tagged image will be built containing the incorrect Ruby version.

This is made more likely if there's a build failure (eg. for ephemeral apt reasons), because the time delta between the images are built and when deploy_multiarch gets the sha and creates the manifest gets larger.

The effect of this bug can be seen by examining the output of the 20251202 image builds where:

- The dated image is built with a particular sha
- The commit tagged image doesn't exist
- A tagged image from a later commit exists, and contains the actually built sha.

```
❯ docker run -it rubylang/ruby:master-20251202 ruby -e 'puts RUBY_REVISION'
0e22108d60fbd0e338fb6e110ddd81a93b45b592

~/git/docker-images master*
❯ docker run --rm rubylang/ruby:master-0e22108d60fbd0e338fb6e110ddd81a93b45b592 ruby -e 'puts RUBY_REVISION'
Unable to find image 'rubylang/ruby:master-0e22108d60fbd0e338fb6e110ddd81a93b45b592' locally

~/git/docker-images master*
❯ docker run --rm rubylang/ruby:master-456ba321a84d34e76c8837ac96f47a11457480cb ruby -e 'puts RUBY_REVISION'
0e22108d60fbd0e338fb6e110ddd81a93b45b592
```