### PR TITLE
Compare versions semantically in ruby_latest_full_version?

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -83,7 +83,9 @@ end
 
 def ruby_latest_full_version?(version)
   ver2 = version.split('.')[0,2].join('.')
-  ruby_versions[ver2][0] == version
+  candidates = ((ruby_versions[ver2] || []) + [version]).uniq.select { |v| v.match?(/\A\d+\.\d+\.\d+\z/) }
+  return false if candidates.empty?
+  candidates.max_by { |v| Gem::Version.new(v) } == version
 end
 
 def ruby_version_exist?(version)


### PR DESCRIPTION
## Summary

`ruby_latest_full_version?` relied on `releases.yml` ordering to emit the `MAJOR.MINOR` alias, so a `repository_dispatch` build that fires before `releases.yml` is updated silently skips it. This is why `4.0` still points at 4.0.2 after the 4.0.3 / 4.0.4 builds.

Compare with `Gem::Version` against a candidate set that always includes the version being built. Re-running the 4.0.4 build is still required to retag `4.0` / `4.0-noble`.

Fixes #165
