### PR TITLE
Sync Docker Hub overview from README.md

### DIFF
--- a/.github/workflows/dockerhub-description.yml
+++ b/.github/workflows/dockerhub-description.yml
@@ -1,0 +1,21 @@
+name: Update Docker Hub description
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - README.md
+  workflow_dispatch:
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: peter-evans/dockerhub-description@1b9a80c056b620d92cedb9d9b5a223409c68ddfa # v5.0.0
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PASS }}
+          repository: rubylang/ruby


### PR DESCRIPTION
Run `peter-evans/dockerhub-description` on master pushes that touch `README.md` to keep them in sync.

Closes #168