### PR TITLE
Update Ruby and Ubuntu versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,7 @@ jobs:
         debug_suffix: ['', '-debug']
         dev_suffix: ['', '-dev']
         ubuntu_version:
+          - resolute
           - noble
           - jammy
         arch: ['amd64', 'arm64']
@@ -131,6 +132,7 @@ jobs:
         registry_name: [rubylang, ghcr.io/ruby]
         image_version_suffix: ['', '-dev', '-debug', '-debug-dev']
         ubuntu_version:
+          - resolute
           - noble
           - jammy
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,10 +19,10 @@ jobs:
           - noble
           - jammy
         ruby_version:
-          - 3.2.8
-          - 3.3.7
-          - 3.4.2
-          - 4.0.0-preview2
+          - 3.2.11
+          - 3.3.11
+          - 3.4.9
+          - 4.0.4
           - master
         arch:
           - amd64

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ jobs:
     strategy:
       matrix:
         ubuntu_version:
+          - resolute
           - noble
           - jammy
         ruby_version:

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This repository provides two flavors of Ruby images for each supported version:
 - **Production** (e.g. `rubylang/ruby:4.0-noble`): minimal image with Ruby and bundler installed.
 - **Development** (e.g. `rubylang/ruby:4.0-dev-noble`): based on the production image, with `build-essential`, `gdb`, and other development tools added. The `-dev` suffix follows the version number.
 
-All images are based on Ubuntu (noble or jammy) and are built by running `make install` on the official Ruby source tarball.
+The images listed below are based on Ubuntu noble, resolute, or jammy, and are built by running `make install` on the official Ruby source tarball. Unsuffixed tags such as `rubylang/ruby:4.0` and `rubylang/ruby:latest` currently track the noble images.
 
 ## Images
 
@@ -45,6 +45,23 @@ All images are based on Ubuntu (noble or jammy) and are built by running `make i
 - 3.3
   - `rubylang/ruby:3.3-noble`
   - `rubylang/ruby:3.3.11-noble`
+
+### Ubuntu 26.04 (resolute)
+
+- master
+  - `rubylang/ruby:master-resolute`
+  - `rubylang/ruby:master-dev-resolute`
+  - `rubylang/ruby:master-debug-resolute`
+  - `rubylang/ruby:master-debug-dev-resolute`
+- 4.0
+  - `rubylang/ruby:4.0-resolute`
+  - `rubylang/ruby:4.0.4-resolute`
+- 3.4
+  - `rubylang/ruby:3.4-resolute`
+  - `rubylang/ruby:3.4.9-resolute`
+- 3.3
+  - `rubylang/ruby:3.3-resolute`
+  - `rubylang/ruby:3.3.11-resolute`
 
 ### Ubuntu 22.04 (jammy)
 

--- a/Rakefile
+++ b/Rakefile
@@ -328,7 +328,7 @@ namespace :docker do
         if tag =~ /#{LATEST_UBUNTU_VERSION}/
           non_ubuntu_tag = tag.sub(/-#{LATEST_UBUNTU_VERSION}/, '')
           sh 'docker', 'manifest', 'create', "#{non_ubuntu_tag}", *amend_args
-          if image_version_suffix.empty? && ruby_version =~ /^#{LATEST_RUBY_VERSION}/ && latest_tag.nil?
+          if image_version_suffix.empty? && ruby_version =~ /\A#{Regexp.escape(LATEST_RUBY_VERSION)}\.\d+\z/ && latest_tag.nil?
             latest_tag = tag.sub(/#{ruby_version}-#{LATEST_UBUNTU_VERSION}/, "latest")
             sh 'docker', 'manifest', 'create', "#{latest_tag}", *amend_args
           end
@@ -349,7 +349,7 @@ namespace :docker do
         if tag =~ /#{LATEST_UBUNTU_VERSION}/
           non_ubuntu_tag = tag.sub(/-#{LATEST_UBUNTU_VERSION}/, '')
           sh 'docker', 'manifest', 'push', "#{non_ubuntu_tag}"
-          if image_version_suffix.empty? && ruby_version =~ /^#{LATEST_RUBY_VERSION}/ && latest_tag.nil?
+          if image_version_suffix.empty? && ruby_version =~ /\A#{Regexp.escape(LATEST_RUBY_VERSION)}\.\d+\z/ && latest_tag.nil?
             latest_tag = tag.sub(/#{ruby_version}-#{LATEST_UBUNTU_VERSION}/, "latest")
             sh 'docker', 'manifest', 'push', "#{latest_tag}"
           end

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,5 @@
 LATEST_UBUNTU_VERSION = "noble"
-LATEST_RUBY_VERSION = "3.4"
+LATEST_RUBY_VERSION = "4.0"
 
 def download(url)
   require "net/http"


### PR DESCRIPTION
Added Ubuntu 26.04(resolute) to our daily build. But `latest` tag still points `noble` while a few month. I update `latest` tag to `resolute` when 26.04.1 is released.