### PR TITLE
ci: declare workflow-level `contents: read` on 2 workflows

### DIFF
--- a/.github/workflows/check-index.yml
+++ b/.github/workflows/check-index.yml
@@ -8,6 +8,9 @@ on:
     branches:
     - check-index-test
 
+permissions:
+  contents: read
+
 jobs:
   build:
 

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: '0 0 * * 2'
 
+permissions:
+  contents: read
+
 jobs:
   mirror:
     name: Mirror images


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` on 2 workflows in `.github/workflows/` that don't call a GitHub API beyond the initial checkout.

The following files were left implicit because they reference `GITHUB_TOKEN` / use a write-scope action / trigger on `pull_request_target`. Those scopes are best declared by maintainers: `build.yml`, `test.yml`.

## Why

CVE-2025-30066 (March 2025 `tj-actions/changed-files` supply-chain compromise) exfiltrated `GITHUB_TOKEN` from workflow logs. Pinning per workflow caps runtime authority irrespective of the repo or org default, gives drift protection if the default ever widens, and is credited per-file by the OpenSSF Scorecard `Token-Permissions` check.

YAML validated locally with `yaml.safe_load` on each touched file.