### PR TITLE
ci: declare workflow-level contents: read on check-index and test

### DIFF
--- a/.github/workflows/check-index.yml
+++ b/.github/workflows/check-index.yml
@@ -8,6 +8,9 @@ on:
     branches:
     - check-index-test
 
+permissions:
+  contents: read
+
 jobs:
   build:
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,9 @@ on:
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: ${{ matrix.ruby_version }}-${{ matrix.ubuntu_version }} ${{ matrix.arch }}


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` at the workflow level. The workflow runs checks only; no GitHub API writes.

Same post-CVE-2025-30066 (`tj-actions/changed-files`) supply-chain hardening pattern. YAML validated locally with `yaml.safe_load`.